### PR TITLE
Use delta time for frame-independent planet rendering

### DIFF
--- a/OptiUniverse/Renderers/PlanetsRenderer.swift
+++ b/OptiUniverse/Renderers/PlanetsRenderer.swift
@@ -6,6 +6,7 @@
 //
 
 import MetalKit
+import QuartzCore
 
 final class PlanetsRenderer {
     private let device: MTLDevice
@@ -14,6 +15,7 @@ final class PlanetsRenderer {
     private var samplerState: MTLSamplerState!
 
     private var time: Float = 0
+    var lastUpdateTime = CACurrentMediaTime()
     var exposure: Float = 1.0
     
     // Solar system data
@@ -114,6 +116,10 @@ final class PlanetsRenderer {
     func renderPlanets(with renderEncoder: MTLRenderCommandEncoder,
                        viewMatrix: float4x4,
                        projectionMatrix: float4x4) {
+        let currentTime = CACurrentMediaTime()
+        let delta = Float(currentTime - lastUpdateTime)
+        lastUpdateTime = currentTime
+
         for planet in planets {
             if planet.name == "Sun" {
                 renderEncoder.setRenderPipelineState(sunPipelineState)
@@ -124,16 +130,18 @@ final class PlanetsRenderer {
             renderPlanet(planet,
                          with: renderEncoder,
                          time: time,
+                         delta: delta,
                          viewMatrix: viewMatrix,
                          projectionMatrix: projectionMatrix)
         }
-        time += 1
+        time += delta
     }
-    
+
     // TODO: Make orbit radius SIM3
     private func renderPlanet(_ planet: Planet,
                               with renderEncoder: MTLRenderCommandEncoder,
                               time: Float,
+                              delta: Float,
                               viewMatrix: float4x4,
                               projectionMatrix: float4x4) {
         
@@ -189,10 +197,15 @@ final class PlanetsRenderer {
                                        length: MemoryLayout<Float>.stride,
                                        index: 0)
 
+        var d = delta
+        renderEncoder.setFragmentBytes(&d,
+                                       length: MemoryLayout<Float>.stride,
+                                       index: 1)
+
         var e = exposure
         renderEncoder.setFragmentBytes(&e,
                                        length: MemoryLayout<Float>.stride,
-                                       index: 1)
+                                       index: 2)
         
         guard let submesh = mtkMesh.submeshes.first else {
             fatalError()

--- a/OptiUniverse/Shaders/Shaders.metal
+++ b/OptiUniverse/Shaders/Shaders.metal
@@ -64,7 +64,8 @@ fragment float4 fragment_main(VertexOut in [[stage_in]],
 // procedural surface and bright corona.
 fragment float4 fragment_sun(VertexOut in [[stage_in]],
                              constant float &time [[buffer(0)]],
-                             constant float &exposure [[buffer(1)]],
+                             constant float &delta [[buffer(1)]],
+                             constant float &exposure [[buffer(2)]],
                              texture2d<float> planetTexture [[texture(0)]],
                              sampler textureSampler [[sampler(0)]]) {
     // Center UV on (0,0)
@@ -72,16 +73,16 @@ fragment float4 fragment_sun(VertexOut in [[stage_in]],
     float r = length(uv);
 
     // Rotate texture coordinates over time for swirling motion
-    float angle = time * 0.1;
+    float angle = time * 0.1 * delta;
     float2 rotUV = float2(uv.x * cos(angle) - uv.y * sin(angle),
                           uv.x * sin(angle) + uv.y * cos(angle));
 
     // Warp UVs using secondary FBM for more turbulent motion
-    float2 warp = fbm(float3(rotUV * 10.0, time * 0.3));
+    float2 warp = fbm(float3(rotUV * 10.0, time * 0.3 * delta));
     rotUV += warp * 0.02;
 
     // Simple procedural noise based on sine waves
-    float noise = sin((rotUV.x + time) * 20.0) * sin((rotUV.y - time) * 20.0);
+    float noise = sin((rotUV.x + time) * 20.0 * delta) * sin((rotUV.y - time) * 20.0 * delta);
     noise = noise * 0.5 + 0.5; // Normalize to 0..1
 
     // Base color mixed with sampled texture to keep some variation
@@ -99,7 +100,7 @@ fragment float4 fragment_sun(VertexOut in [[stage_in]],
     const float freqs[3] = {1.0, 2.0, 4.0};
     for (int i = 0; i < 3; ++i) {
         float f = freqs[i];
-        float layer = sin((rotUV.x + time) * 20.0 * f) * sin((rotUV.y - time) * 20.0 * f);
+        float layer = sin((rotUV.x + time) * 20.0 * f * delta) * sin((rotUV.y - time) * 20.0 * f * delta);
         layer = layer * 0.5 + 0.5;
         corona += float3(10.0, 5.0, 1.0) * (1.0 / (float(i) + 1.0)) * layer;
     }


### PR DESCRIPTION
## Summary
- Track render frame intervals in `PlanetsRenderer` using `CACurrentMediaTime`
- Pass frame `delta` to `fragment_sun` and apply it to animation calculations
- Replace fixed frame increments with delta-based timing

## Testing
- `xcodebuild build -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*
- `xcodebuild test -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c24a1714832789271b28fd1d8449