### PR TITLE
Add object selection menu with camera zoom

### DIFF
--- a/OptiUniverse/ContentView.swift
+++ b/OptiUniverse/ContentView.swift
@@ -8,13 +8,23 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedPlanet: String?
+    private let planetNames = SolarSystemLoader.loadPlanets(from: "planets").map { $0.name }
+
     var body: some View {
         NavigationView {
-            UniverseView()
+            UniverseView(selectedPlanet: $selectedPlanet)
                 .navigationTitle("Solar System")
                 .toolbar {
-                    Button("Settings") {
-                        // Open settings
+                    ToolbarItemGroup(placement: .navigationBarTrailing) {
+                        Menu("Objects") {
+                            ForEach(planetNames, id: \.self) { name in
+                                Button(name) { selectedPlanet = name }
+                            }
+                        }
+                        Button("Settings") {
+                            // Open settings
+                        }
                     }
                 }
         }

--- a/OptiUniverse/UniverseView.swift
+++ b/OptiUniverse/UniverseView.swift
@@ -10,6 +10,12 @@ import MetalKit
 import UIKit
 
 struct UniverseView: UIViewRepresentable {
+    @Binding var selectedPlanet: String?
+
+    init(selectedPlanet: Binding<String?> = .constant(nil)) {
+        _selectedPlanet = selectedPlanet
+    }
+
     func makeCoordinator() -> RendererCoordinator {
         RendererCoordinator()
     }
@@ -58,12 +64,20 @@ struct UniverseView: UIViewRepresentable {
         return container
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {}
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if context.coordinator.currentSelectedPlanet != selectedPlanet {
+            context.coordinator.currentSelectedPlanet = selectedPlanet
+            if let name = selectedPlanet {
+                context.coordinator.renderer?.followPlanet(named: name)
+            }
+        }
+    }
 }
 
 class RendererCoordinator: NSObject, PlanetLabelDelegate {
     var renderer: MetalRenderer?
     private var labels: [String: UILabel] = [:]
+    var currentSelectedPlanet: String?
 
     // Touch state
     private var lastPanLocation: CGPoint = .zero


### PR DESCRIPTION
## Summary
- Add SwiftUI toolbar menu listing celestial objects
- Bind UniverseView to the selected object and trigger camera zoom

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e299ca608327b27da563928a24ea