### PR TITLE
Add accessibility identifiers for QA UI elements

### DIFF
--- a/OptiUniverse/ContentView.swift
+++ b/OptiUniverse/ContentView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedPlanet: String?
+    @State private var selectedPreset: String = "High"
+    @State private var selectedDistance: String = "Near"
     private let planetNames = SolarSystemLoader.loadPlanets(from: "planets").map { $0.name }
 
     var body: some View {
@@ -22,13 +24,39 @@ struct ContentView: View {
                                   Button(name) { selectedPlanet = name }
                               }
                           }
+                          Menu("Preset") {
+                              Button("Low") { selectedPreset = "Low" }
+                                  .accessibilityIdentifier("Preset_Low")
+                              Button("Medium") { selectedPreset = "Medium" }
+                                  .accessibilityIdentifier("Preset_Medium")
+                              Button("High") { selectedPreset = "High" }
+                                  .accessibilityIdentifier("Preset_High")
+                              Button("Cinematic") { selectedPreset = "Cinematic" }
+                                  .accessibilityIdentifier("Preset_Cinematic")
+                          }
+                          Menu("Distance") {
+                              Button("Near") { selectedDistance = "Near" }
+                                  .accessibilityIdentifier("Distance_Near")
+                              Button("Far") { selectedDistance = "Far" }
+                                  .accessibilityIdentifier("Distance_Far")
+                          }
                           Button("Settings") {
                               // Open settings
                           }
+                          .accessibilityIdentifier("Settings")
                           if QALaunch.enabled {
                               Button("Export_QA") {
                                   QAHooks.export()
                               }
+                              .accessibilityIdentifier("Export_QA")
+                              Button("QA_SampleMemory") {
+                                  QAHooks.sampleMemory()
+                              }
+                              .accessibilityIdentifier("QA_SampleMemory")
+                              Button("QA_ExportStability") {
+                                  QAHooks.exportStability()
+                              }
+                              .accessibilityIdentifier("QA_ExportStability")
                           }
                       }
                   }

--- a/OptiUniverse/QAHooks.swift
+++ b/OptiUniverse/QAHooks.swift
@@ -57,6 +57,11 @@ final class QAMetrics {
         }
     }
 
+    /// Records a standalone memory sample.
+    func sampleMemory() {
+        memory.sample()
+    }
+
     /// Creates a dictionary suitable for JSON serialization of collected metrics.
     func exportJSON() -> [String: Any] {
         let fps: Double
@@ -91,6 +96,12 @@ enum QAHooks {
         metrics.tick(commandBuffer: commandBuffer)
     }
 
+    /// Records a manual memory sample.
+    static func sampleMemory() {
+        guard QALaunch.enabled else { return }
+        metrics.sampleMemory()
+    }
+
     /// Writes collected metrics to a JSON file in the temporary directory.
     static func export() {
         guard QALaunch.enabled else { return }
@@ -102,6 +113,20 @@ enum QAHooks {
             print("QA metrics exported to \(url.path)")
         } catch {
             print("Failed to export QA metrics: \(error)")
+        }
+    }
+
+    /// Exports stability metrics to a separate JSON file.
+    static func exportStability() {
+        guard QALaunch.enabled else { return }
+        let json = metrics.exportJSON()
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("qa_stability.json")
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+            try data.write(to: url)
+            print("QA stability exported to \(url.path)")
+        } catch {
+            print("Failed to export QA stability: \(error)")
         }
     }
 }


### PR DESCRIPTION
Resolves #26
## Summary
- Add preset and distance menus with unique accessibility identifiers for XCUITests
- Tag Settings, QA export, memory sampling, and stability actions with identifiers
- Expose QA hooks for manual memory sampling and stability export

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c31454af7c8327aa78a563425cc1ba