### PR TITLE
Track per-pass GPU timings

### DIFF
--- a/OptiUniverse/QAHooks.swift
+++ b/OptiUniverse/QAHooks.swift
@@ -35,25 +35,26 @@ final class QAMemory {
 /// Gathers frame, GPU and memory metrics during rendering.
 final class QAMetrics {
     private var frameTimes: [Double] = []
-    private var gpuTimes: [Double] = []
+    private var gpuTimes: [String: [Double]] = [:]
     private var lastFrameTimestamp: CFTimeInterval?
     private let memory = QAMemory()
 
-    /// Should be called once per frame with the active command buffer.
-    func tick(commandBuffer: MTLCommandBuffer) {
+    /// Tracks a render pass' GPU time and optionally frame timing.
+    func tick(commandBuffer: MTLCommandBuffer, pass: String, recordFrame: Bool = false) {
         let now = CACurrentMediaTime()
-        if let last = lastFrameTimestamp {
-            frameTimes.append(now - last)
+        if recordFrame {
+            if let last = lastFrameTimestamp {
+                frameTimes.append(now - last)
+            }
+            lastFrameTimestamp = now
+            memory.sample()
         }
-        lastFrameTimestamp = now
-
-        memory.sample()
 
         let start = now
         commandBuffer.addCompletedHandler { [weak self] _ in
             let end = CACurrentMediaTime()
             let ms = (end - start) * 1000
-            self?.gpuTimes.append(ms)
+            self?.gpuTimes[pass, default: []].append(ms)
         }
     }
 
@@ -71,16 +72,25 @@ final class QAMetrics {
             let avg = frameTimes.reduce(0, +) / Double(frameTimes.count)
             fps = avg > 0 ? 1.0 / avg : 0
         }
-        let sortedGPU = gpuTimes.sorted()
-        func percentile(_ p: Double) -> Double {
-            guard !sortedGPU.isEmpty else { return 0 }
-            let pos = (Double(sortedGPU.count - 1)) * p
-            return sortedGPU[Int(pos.rounded(.towardZero))]
+
+        func percentile(_ sorted: [Double], _ p: Double) -> Double {
+            guard !sorted.isEmpty else { return 0 }
+            let pos = (Double(sorted.count - 1)) * p
+            return sorted[Int(pos.rounded(.towardZero))]
         }
+
+        var gpuStats: [String: [String: Double]] = [:]
+        for (pass, times) in gpuTimes {
+            let sorted = times.sorted()
+            gpuStats[pass] = [
+                "p50": percentile(sorted, 0.50),
+                "p95": percentile(sorted, 0.95)
+            ]
+        }
+
         return [
             "fps": fps,
-            "gpu_ms_p50": percentile(0.50),
-            "gpu_ms_p95": percentile(0.95),
+            "gpu_ms": gpuStats,
             "mem_samples": memory.samples
         ]
     }
@@ -90,10 +100,15 @@ final class QAMetrics {
 enum QAHooks {
     private static let metrics = QAMetrics()
 
-    /// Called from the render loop every frame to gather metrics.
-    static func tick(commandBuffer: MTLCommandBuffer) {
+    /// Called from the render loop to gather per-pass metrics.
+    static func tick(commandBuffer: MTLCommandBuffer, pass: String, recordFrame: Bool = false) {
         guard QALaunch.enabled else { return }
-        metrics.tick(commandBuffer: commandBuffer)
+        metrics.tick(commandBuffer: commandBuffer, pass: pass, recordFrame: recordFrame)
+    }
+
+    /// Backwards-compatible tick for whole-frame measurements.
+    static func tick(commandBuffer: MTLCommandBuffer) {
+        tick(commandBuffer: commandBuffer, pass: "frame", recordFrame: true)
     }
 
     /// Records a manual memory sample.

--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -127,14 +127,13 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     }
 
     func draw(in view: MTKView) {
-        guard let commandBuffer = commandQueue.makeCommandBuffer(),
-              let hdrTexture = hdrTexture,
+        guard let hdrTexture = hdrTexture,
               let msaaColorTexture = msaaColorTexture,
               let depthTexture = depthTexture,
               let tonemapMsaaTexture = tonemapMsaaTexture,
               let drawable = view.currentDrawable else {
-            return
-        }
+              return
+          }
 
         // Advance simulation time and update camera before rendering so that
         // the view matches the planets' latest positions within the same frame.
@@ -148,6 +147,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         }
 
         // First pass: render scene to MSAA texture and resolve to HDR texture
+        guard let geometryCommandBuffer = commandQueue.makeCommandBuffer() else { return }
         let hdrDescriptor = MTLRenderPassDescriptor()
         hdrDescriptor.colorAttachments[0].texture = msaaColorTexture
         hdrDescriptor.colorAttachments[0].resolveTexture = hdrTexture
@@ -159,7 +159,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         hdrDescriptor.depthAttachment.storeAction = .dontCare
         hdrDescriptor.depthAttachment.clearDepth = 1.0
 
-        guard let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: hdrDescriptor) else {
+        guard let renderEncoder = geometryCommandBuffer.makeRenderCommandEncoder(descriptor: hdrDescriptor) else {
             return
         }
 
@@ -183,10 +183,15 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                 projectionMatrix: projectionMatrix)
         renderEncoder.endEncoding()
 
+        // Collect QA metrics and submit first pass
+        QAHooks.tick(commandBuffer: geometryCommandBuffer, pass: "geometry", recordFrame: true)
+        geometryCommandBuffer.commit()
+
         // Update any label overlays with the latest planet positions
         labelDelegate?.updatePlanetLabels(planetsRenderer.planetScreenPositions)
 
         // Second pass: tone map to drawable using MSAA and resolve to the drawable
+        guard let tonemapCommandBuffer = commandQueue.makeCommandBuffer() else { return }
         let finalDescriptor = MTLRenderPassDescriptor()
         finalDescriptor.colorAttachments[0].texture = tonemapMsaaTexture
         finalDescriptor.colorAttachments[0].resolveTexture = drawable.texture
@@ -194,18 +199,17 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         finalDescriptor.colorAttachments[0].storeAction = .multisampleResolve
         finalDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
 
-        if let quadEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: finalDescriptor) {
+        if let quadEncoder = tonemapCommandBuffer.makeRenderCommandEncoder(descriptor: finalDescriptor) {
             quadEncoder.setRenderPipelineState(tonemapPipelineState)
             quadEncoder.setFragmentTexture(hdrTexture, index: 0)
             quadEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
             quadEncoder.endEncoding()
         }
 
-        // Collect QA metrics before submitting the command buffer
-        QAHooks.tick(commandBuffer: commandBuffer)
+        QAHooks.tick(commandBuffer: tonemapCommandBuffer, pass: "tonemap")
 
-        commandBuffer.present(drawable)
-        commandBuffer.commit()
+        tonemapCommandBuffer.present(drawable)
+        tonemapCommandBuffer.commit()
     }
     
     private func updateProjectionMatrix() {


### PR DESCRIPTION
Resolves #27
## Summary
- record GPU timings per render pass via named command buffers
- expose pass-level p50/p95 metrics through QA hooks
- split rendering into geometry and tonemap command buffers

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3167648448327a216da4ea3566f9f