### PR TITLE
Add prominence particle compute and render shaders

### DIFF
--- a/OptiUniverse/Shaders/Prominences.compute.metal
+++ b/OptiUniverse/Shaders/Prominences.compute.metal
@@ -1,0 +1,50 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct ProminenceParticle {
+    float3 position;
+    float  angle;   // angle around the sun's limb
+    float  life;    // remaining life time
+};
+
+// Simple deterministic pseudo-random generator
+static float rand(float x) {
+    return fract(sin(x) * 43758.5453);
+}
+
+kernel void updateProminenceParticles(
+    device ProminenceParticle *particles [[buffer(0)]],
+    constant uint            &particleCount [[buffer(1)]],
+    constant float           &arcHeight     [[buffer(2)]],
+    constant float           &lifetime      [[buffer(3)]],
+    constant float           &time          [[buffer(4)]],
+    constant float           &delta         [[buffer(5)]],
+    uint id [[thread_position_in_grid]]) {
+
+    if (id >= particleCount) return;
+
+    ProminenceParticle p = particles[id];
+    p.life -= delta;
+
+    // Respawn when life ends
+    if (p.life <= 0.0) {
+        float seed = rand(float(id) + time);
+        p.angle = seed * 2.0 * M_PI_F;
+        p.life = lifetime;
+    }
+
+    float progress = 1.0 - p.life / lifetime; // 0 at spawn -> 1 at death
+
+    // Base position on the limb
+    float3 base = float3(cos(p.angle), 0.0, sin(p.angle));
+
+    // Semi-circular arc
+    float height = sin(progress * M_PI_F) * arcHeight;
+    float radial = 1.0 + (1.0 - cos(progress * M_PI_F)) * 0.1;
+
+    p.position = base * radial;
+    p.position.y = height;
+
+    particles[id] = p;
+}
+

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -1,0 +1,38 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct ProminenceParticle {
+    float3 position;
+    float  angle;
+    float  life;
+};
+
+struct VertexOut {
+    float4 position [[position]];
+    float  life;
+    float  pointSize [[point_size]];
+};
+
+vertex VertexOut prominence_vertex(
+    const device ProminenceParticle *particles [[buffer(0)]],
+    constant float4x4 &mvpMatrix [[buffer(1)]],
+    constant float    &lifetime  [[buffer(2)]],
+    uint id [[vertex_id]]) {
+
+    ProminenceParticle p = particles[id];
+    VertexOut out;
+    out.position = mvpMatrix * float4(p.position, 1.0);
+    out.life = p.life;
+    float age = 1.0 - p.life / lifetime;
+    out.pointSize = 1.0 + (1.0 - age) * 2.0;
+    return out;
+}
+
+fragment float4 prominence_fragment(VertexOut in [[stage_in]],
+                                    constant float &lifetime [[buffer(0)]]) {
+    float age = 1.0 - in.life / lifetime;
+    float alpha = (1.0 - age) * (1.0 - age);
+    float3 color = float3(1.0, 0.5, 0.2) * alpha;
+    return float4(color, alpha); // Additive blending expected
+}
+


### PR DESCRIPTION
Resolves #61
## Summary
- introduce compute shader updating prominence particles along magnetic arcs
- add render shader for additive prominence particles with life-based sizing

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42c9931ec8327ab1aacf9680a7108