### PR TITLE
Fix float3 constructor in Chromosphere shader

### DIFF
--- a/OptiUniverse/Shaders/Chromosphere.metal
+++ b/OptiUniverse/Shaders/Chromosphere.metal
@@ -50,7 +50,7 @@ fragment float4 chromosphere_fragment(VertexOut in [[stage_in]],
     float rim = pow(max(0.0, 1.0 - mu), rimFalloff);
     if (rim <= 0.001) discard_fragment();
 
-    float flicker = fbm(float3(in.worldPos * 10.0, time * flickerSpeed));
+    float flicker = fbm(in.worldPos * 10.0 + float3(0.0, 0.0, time * flickerSpeed));
     flicker = 0.8 + 0.2 * flicker;
 
     float intensity = rimIntensity * rim * flicker;


### PR DESCRIPTION
## Summary
- Correct float3 initialization in Chromosphere shader by adding a time-based offset

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44d56046083279008b5d7c7482745