### PR TITLE
Add runtime quality preset manager

### DIFF
--- a/OptiUniverse/Engine/QualityManager.swift
+++ b/OptiUniverse/Engine/QualityManager.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Represents predefined engine quality presets.
+enum QualityPreset: String, CaseIterable, Codable {
+    case low
+    case medium
+    case high
+    case cinematic
+}
+
+/// Available rendering approaches for the solar corona.
+enum CoronaMode: String, Codable {
+    case off
+    case simple
+    case detailed
+}
+
+/// Bundle of parameters that scale with a quality preset.
+struct QualityConfiguration: Codable {
+    /// Number of ray-march steps for volumetric corona rendering.
+    let coronaSteps: UInt
+    /// Number of particles to emit for effects such as dust or debris.
+    let particleCount: Int
+    /// Corona rendering technique to use.
+    let coronaMode: CoronaMode
+}
+
+/// Central manager responsible for runtime quality scaling.
+final class QualityManager {
+    /// Shared singleton instance.
+    static let shared = QualityManager()
+
+    /// Mapping from preset to configuration values.
+    private let configs: [QualityPreset: QualityConfiguration]
+
+    /// Currently active preset.
+    private(set) var currentPreset: QualityPreset
+
+    private init(bundle: Bundle = .main) {
+        if
+            let url = bundle.url(forResource: "QualityPresets", withExtension: "json"),
+            let data = try? Data(contentsOf: url),
+            let decoded = try? JSONDecoder().decode([QualityPreset: QualityConfiguration].self, from: data)
+        {
+            configs = decoded
+        } else {
+            configs = [
+                .low: .init(coronaSteps: 8, particleCount: 500, coronaMode: .off),
+                .medium: .init(coronaSteps: 16, particleCount: 1_000, coronaMode: .simple),
+                .high: .init(coronaSteps: 24, particleCount: 2_000, coronaMode: .detailed),
+                .cinematic: .init(coronaSteps: 32, particleCount: 4_000, coronaMode: .detailed)
+            ]
+        }
+        currentPreset = .high
+    }
+
+    /// Switches to a new quality preset without rebuilding render pipelines.
+    func apply(preset: QualityPreset) {
+        guard currentPreset != preset else { return }
+        currentPreset = preset
+        NotificationCenter.default.post(name: .qualityPresetChanged, object: self)
+    }
+
+    /// Current number of corona ray-march steps.
+    var coronaSteps: UInt { configs[currentPreset]?.coronaSteps ?? 0 }
+    /// Current particle emission count.
+    var particleCount: Int { configs[currentPreset]?.particleCount ?? 0 }
+    /// Currently selected corona rendering mode.
+    var coronaMode: CoronaMode { configs[currentPreset]?.coronaMode ?? .off }
+}
+
+extension Notification.Name {
+    /// Fired whenever the quality preset changes at runtime.
+    static let qualityPresetChanged = Notification.Name("QualityPresetChanged")
+}
+

--- a/OptiUniverse/Renderers/CoronaQuality.swift
+++ b/OptiUniverse/Renderers/CoronaQuality.swift
@@ -1,18 +1,10 @@
 import Foundation
 
-/// Quality preset controlling corona ray-march step count.
-enum CoronaQualityPreset: Int {
-    case low
-    case medium
-    case high
-
-    /// Number of ray-march steps for the preset.
-    var stepCount: UInt {
-        switch self {
-        case .low: return 8
-        case .medium: return 16
-        case .high: return 24
-        }
+/// Thin wrapper accessing corona ray-march steps via `QualityManager`.
+enum CoronaQuality {
+    /// Number of ray-march steps for the active quality preset.
+    static var stepCount: UInt {
+        QualityManager.shared.coronaSteps
     }
 }
 

--- a/OptiUniverse/Resources/QualityPresets.json
+++ b/OptiUniverse/Resources/QualityPresets.json
@@ -1,0 +1,6 @@
+{
+  "low":    { "coronaSteps": 8,  "particleCount": 500,  "coronaMode": "off" },
+  "medium": { "coronaSteps": 16, "particleCount": 1000, "coronaMode": "simple" },
+  "high":   { "coronaSteps": 24, "particleCount": 2000, "coronaMode": "detailed" },
+  "cinematic": { "coronaSteps": 32, "particleCount": 4000, "coronaMode": "detailed" }
+}


### PR DESCRIPTION
Resolves  #63
## Summary
- Introduce `QualityManager` to centralize quality presets
- Provide JSON-driven config for corona steps, particle counts and modes
- Expose corona step count via `CoronaQuality` wrapper

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c450d55c908327827234035e0d10e1