### PR TITLE
Add SwiftUI debug panel for runtime quality tuning

### DIFF
--- a/DebugPanelParameters.md
+++ b/DebugPanelParameters.md
@@ -1,0 +1,9 @@
+# Debug Panel Parameters
+
+| Parameter | Range | Description |
+|-----------|-------|-------------|
+| Quality Preset | low, medium, high, cinematic | Predefined render configurations. |
+| Corona Steps | 0–64 | Ray-march iterations for corona. |
+| Corona Mode | off, simple, detailed | Rendering technique for corona. |
+| Particle Count | 0–5000 | Number of emitted particles. |
+| Exposure | 0.1–5.0 | Multiplier applied to final color. |

--- a/OptiUniverse/DebugPanelView.swift
+++ b/OptiUniverse/DebugPanelView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Simple developer panel enabling runtime tweaking of rendering parameters.
+struct DebugPanelView: View {
+    @ObservedObject private var quality = QualityManager.shared
+
+    var body: some View {
+        Form {
+            Section(header: Text("Preset")) {
+                Picker("Preset", selection: Binding(
+                    get: { quality.currentPreset },
+                    set: { quality.apply(preset: $0) }
+                )) {
+                    ForEach(QualityPreset.allCases, id: \.self) { preset in
+                        Text(preset.rawValue.capitalized).tag(preset)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section(header: Text("Corona")) {
+                Slider(value: Binding(
+                    get: { Double(quality.coronaSteps) },
+                    set: { quality.coronaSteps = UInt($0) }
+                ), in: 0...64, step: 1) {
+                    Text("Steps")
+                }
+                Text("Steps: \(quality.coronaSteps)")
+
+                Picker("Mode", selection: $quality.coronaMode) {
+                    Text("Off").tag(CoronaMode.off)
+                    Text("Simple").tag(CoronaMode.simple)
+                    Text("Detailed").tag(CoronaMode.detailed)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section(header: Text("Particles")) {
+                Slider(value: Binding(
+                    get: { Double(quality.particleCount) },
+                    set: { quality.particleCount = Int($0) }
+                ), in: 0...5000, step: 100) {
+                    Text("Count")
+                }
+                Text("Count: \(quality.particleCount)")
+            }
+
+            Section(header: Text("Exposure")) {
+                Slider(value: $quality.exposure, in: 0.1...5.0) {
+                    Text("Exposure")
+                }
+                Text(String(format: "%.2f", quality.exposure))
+            }
+        }
+    }
+}
+
+#Preview {
+    DebugPanelView()
+}

--- a/OptiUniverse/Engine/QualityManager.swift
+++ b/OptiUniverse/Engine/QualityManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// Represents predefined engine quality presets.
 enum QualityPreset: String, CaseIterable, Codable {
@@ -26,7 +27,7 @@ struct QualityConfiguration: Codable {
 }
 
 /// Central manager responsible for runtime quality scaling.
-final class QualityManager {
+final class QualityManager: ObservableObject {
     /// Shared singleton instance.
     static let shared = QualityManager()
 
@@ -34,7 +35,18 @@ final class QualityManager {
     private let configs: [QualityPreset: QualityConfiguration]
 
     /// Currently active preset.
-    private(set) var currentPreset: QualityPreset
+    @Published var currentPreset: QualityPreset {
+        didSet { updateConfiguration() }
+    }
+
+    /// Current number of corona ray-march steps.
+    @Published var coronaSteps: UInt
+    /// Current particle emission count.
+    @Published var particleCount: Int
+    /// Currently selected corona rendering mode.
+    @Published var coronaMode: CoronaMode
+    /// Exposure multiplier passed to shaders.
+    @Published var exposure: Float
 
     private init(bundle: Bundle = .main) {
         if
@@ -52,21 +64,26 @@ final class QualityManager {
             ]
         }
         currentPreset = .high
+        coronaSteps = configs[currentPreset]!.coronaSteps
+        particleCount = configs[currentPreset]!.particleCount
+        coronaMode = configs[currentPreset]!.coronaMode
+        exposure = 1.0
     }
 
     /// Switches to a new quality preset without rebuilding render pipelines.
     func apply(preset: QualityPreset) {
         guard currentPreset != preset else { return }
         currentPreset = preset
-        NotificationCenter.default.post(name: .qualityPresetChanged, object: self)
     }
 
-    /// Current number of corona ray-march steps.
-    var coronaSteps: UInt { configs[currentPreset]?.coronaSteps ?? 0 }
-    /// Current particle emission count.
-    var particleCount: Int { configs[currentPreset]?.particleCount ?? 0 }
-    /// Currently selected corona rendering mode.
-    var coronaMode: CoronaMode { configs[currentPreset]?.coronaMode ?? .off }
+    private func updateConfiguration() {
+        if let config = configs[currentPreset] {
+            coronaSteps = config.coronaSteps
+            particleCount = config.particleCount
+            coronaMode = config.coronaMode
+        }
+        NotificationCenter.default.post(name: .qualityPresetChanged, object: self)
+    }
 }
 
 extension Notification.Name {

--- a/OptiUniverse/Renderers/PlanetsRenderer.swift
+++ b/OptiUniverse/Renderers/PlanetsRenderer.swift
@@ -17,7 +17,6 @@ final class PlanetsRenderer {
 
     private var time: Float = 0
     var lastUpdateTime = CACurrentMediaTime()
-    var exposure: Float = 1.0
 
     /// Model matrix of the Sun without scaling.
     /// Updated each frame when the Sun is rendered so other renderers
@@ -287,7 +286,7 @@ final class PlanetsRenderer {
                                        length: MemoryLayout<Float>.stride,
                                        index: 1)
 
-        var e = exposure
+        var e = QualityManager.shared.exposure
         renderEncoder.setFragmentBytes(&e,
                                        length: MemoryLayout<Float>.stride,
                                        index: 2)


### PR DESCRIPTION
Resolves #65
## Summary
- add `DebugPanelView` for adjusting quality presets and render params at runtime
- expose `QualityManager` settings via `ObservableObject` including shader exposure control
- route planet renderer exposure through `QualityManager` and document parameter ranges

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c456f8ef888327b21cc63065d3adb1