### PR TITLE
Integrate dedicated Sun renderer into Metal scene

### DIFF
--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -29,6 +29,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let device: MTLDevice
     private let commandQueue: MTLCommandQueue
     private let planetsRenderer: PlanetsRenderer
+    private let sunRenderer: SunRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -84,6 +85,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         self.commandQueue = commandQueue
         self.metalView = metalView
         planetsRenderer = PlanetsRenderer(device: device)
+        sunRenderer = SunRenderer(device: device)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -150,6 +152,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         // Advance simulation time and update camera before rendering so that
         // the view matches the planets' latest positions within the same frame.
         let delta = planetsRenderer.advanceTime()
+        let time = planetsRenderer.currentTime
         if cameraAnimationProgress < 1 {
             updateCameraAnimation(delta: delta)
         } else if let name = followingPlanetName,
@@ -175,6 +178,15 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             return
         }
 
+        // Render the Sun first so depth testing handles planet occlusion.
+        sunRenderer.renderSun(with: renderEncoder,
+                              time: time,
+                              delta: delta,
+                              viewMatrix: viewMatrix,
+                              projectionMatrix: projectionMatrix,
+                              viewportSize: metalView.bounds.size)
+
+        // Render the remaining planets.
         planetsRenderer.renderPlanets(with: renderEncoder,
                                       viewMatrix: viewMatrix,
                                       projectionMatrix: projectionMatrix,
@@ -192,7 +204,14 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         geometryCommandBuffer.commit()
 
         // Update any label overlays with the latest planet positions
-        labelDelegate?.updatePlanetLabels(planetsRenderer.planetScreenPositions)
+        var positions = planetsRenderer.planetScreenPositions
+        if let sunPos = sunRenderer.screenPosition {
+            positions[sunRenderer.name] = sunPos
+        }
+        if let sunWorld = sunRenderer.worldPosition {
+            planetsRenderer.planetWorldPositions[sunRenderer.name] = sunWorld
+        }
+        labelDelegate?.updatePlanetLabels(positions)
 
         // Second pass: post-process to drawable using MSAA and resolve to the drawable
         guard let postfxCommandBuffer = commandQueue.makeCommandBuffer() else { return }
@@ -234,6 +253,14 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     /// distance based on the planet's radius.
     func followPlanet(named name: String) {
         followingPlanetName = name
+        if name == sunRenderer.name {
+            startCameraTarget = cameraTarget
+            endCameraTarget = sunRenderer.worldPosition ?? SIMD3<Float>(0, 0, 0)
+            startCameraDistance = cameraDistance
+            endCameraDistance = max(sunRenderer.radius * 5, 0.1)
+            cameraAnimationProgress = 0
+            return
+        }
 
         if let position = planetsRenderer.worldPosition(ofPlanetNamed: name) {
             startCameraTarget = cameraTarget

--- a/OptiUniverse/Renderers/PlanetsRenderer.swift
+++ b/OptiUniverse/Renderers/PlanetsRenderer.swift
@@ -12,16 +12,10 @@ import simd
 final class PlanetsRenderer {
     private let device: MTLDevice
     var pipelineState: MTLRenderPipelineState!
-    private var sunPipelineState: MTLRenderPipelineState!
     private var samplerState: MTLSamplerState!
 
     private var time: Float = 0
     var lastUpdateTime = CACurrentMediaTime()
-
-    /// Model matrix of the Sun without scaling.
-    /// Updated each frame when the Sun is rendered so other renderers
-    /// (e.g. debug axes) can match its position and rotation.
-    var sunModelMatrix: float4x4 = matrix_identity_float4x4
     
     // Solar system data
     private var planets: [Planet] = []
@@ -39,15 +33,18 @@ final class PlanetsRenderer {
     init(device: MTLDevice) {
         self.device = device
         pipelineState = makePipelineState(fragmentFunction: "fragment_main")
-        sunPipelineState = makePipelineState(fragmentFunction: "fragment_sun")
         samplerState = makeSamplerState()
-        planets = SolarSystemLoader.loadPlanets(from: "planets")
+        // Exclude the Sun; it's rendered separately by `SunRenderer`.
+        planets = SolarSystemLoader.loadPlanets(from: "planets").filter { $0.name != "Sun" }
     }
 
     /// Returns the `Planet` instance for the given name if it exists.
     func planet(named name: String) -> Planet? {
         planets.first { $0.name == name }
     }
+
+    /// Current simulation time used for planet animations.
+    var currentTime: Float { time }
 
     /// Builds a render pipeline for the given fragment function.
     ///
@@ -182,12 +179,7 @@ final class PlanetsRenderer {
         planetWorldPositions.removeAll()
 
         for planet in planets {
-            if planet.name == "Sun" {
-                renderEncoder.setRenderPipelineState(sunPipelineState)
-            } else {
-                renderEncoder.setRenderPipelineState(pipelineState)
-            }
-
+            renderEncoder.setRenderPipelineState(pipelineState)
             renderPlanet(planet,
                          with: renderEncoder,
                          time: time,
@@ -225,11 +217,6 @@ final class PlanetsRenderer {
 
         // 3. Combine transformations (mesh already scaled to radius)
         var modelMatrix = rotationMatrix * translationMatrix
-
-        // Store Sun transform for debug axes
-        if planet.name == "Sun" {
-            sunModelMatrix = modelMatrix
-        }
 
         // 4. Create MVP matrix
         var mvpMatrix = projectionMatrix * viewMatrix * modelMatrix

--- a/OptiUniverse/Renderers/SunRenderer.swift
+++ b/OptiUniverse/Renderers/SunRenderer.swift
@@ -1,0 +1,192 @@
+//
+//  SunRenderer.swift
+//  OptiUniverse
+//
+//  Created for APP-03.
+//
+
+import MetalKit
+import simd
+
+/// Dedicated renderer for the Sun. Generates a procedural photosphere
+/// and corona using the `fragment_sun` shader. The renderer exposes the
+/// latest model matrix so other systems can align with the Sun in the
+/// scene graph.
+final class SunRenderer {
+    private let device: MTLDevice
+    private let pipelineState: MTLRenderPipelineState
+    private let samplerState: MTLSamplerState
+    private var mesh: MDLMesh
+    private var texture: MTLTexture
+
+    /// Model matrix without scaling. Updated every frame after calling
+    /// `renderSun` so that other renderers can query the Sun's transform.
+    var modelMatrix: float4x4 = matrix_identity_float4x4
+
+    /// Screen-space center position of the Sun after the last render call.
+    var screenPosition: SIMD2<Float>?
+    /// World-space center position of the Sun after the last render call.
+    var worldPosition: SIMD3<Float>?
+
+    private let sun: Planet
+
+    /// Radius of the Sun in scene units for camera framing.
+    var radius: Float { sun.radius }
+    /// Name of the rendered body for lookup convenience.
+    var name: String { sun.name }
+
+    init(device: MTLDevice) {
+        self.device = device
+        self.pipelineState = SunRenderer.makePipelineState(device: device)
+        self.samplerState = SunRenderer.makeSamplerState(device: device)
+        self.sun = SolarSystemLoader.loadPlanets(from: "sun").first!
+        // Pre-build mesh and texture since the Sun's size does not change.
+        self.mesh = SunRenderer.createTexturedSphere(device: device,
+                                                     radius: sun.radius,
+                                                     textureName: sun.textureName)
+        self.texture = SunRenderer.loadTexture(device: device,
+                                               name: sun.textureName)
+    }
+
+    /// Renders the Sun using the provided encoder.
+    /// - Parameters:
+    ///   - renderEncoder: Encoder from the main render pass.
+    ///   - time: Global simulation time used for animation.
+    ///   - delta: Time since last frame.
+    ///   - viewMatrix: View matrix.
+    ///   - projectionMatrix: Projection matrix.
+    func renderSun(with renderEncoder: MTLRenderCommandEncoder,
+                   time: Float,
+                   delta: Float,
+                   viewMatrix: float4x4,
+                   projectionMatrix: float4x4,
+                   viewportSize: CGSize) {
+        // The Sun is placed at the origin but we keep transformation logic to
+        // stay consistent with planets and allow future movement if needed.
+        let rotation = float4x4.makeRotationZ(time * sun.orbitSpeed)
+        let translation = float4x4.makeTranslation([sun.distance, 0, 0])
+        modelMatrix = rotation * translation
+
+        // Calculate world and screen positions for label overlays.
+        let worldPos4 = modelMatrix * SIMD4<Float>(0, 0, 0, 1)
+        worldPosition = SIMD3<Float>(worldPos4.x, worldPos4.y, worldPos4.z)
+        let clip = projectionMatrix * viewMatrix * worldPos4
+        if clip.w > 0 {
+            let ndc = clip / clip.w
+            if abs(ndc.x) <= 1, abs(ndc.y) <= 1, ndc.z >= 0, ndc.z <= 1 {
+                let x = (ndc.x + 1) * 0.5 * Float(viewportSize.width)
+                let y = (ndc.y + 1) * 0.5 * Float(viewportSize.height)
+                screenPosition = SIMD2<Float>(x, y)
+            } else {
+                screenPosition = nil
+            }
+        } else {
+            screenPosition = nil
+        }
+
+        var mvpMatrix = projectionMatrix * viewMatrix * modelMatrix
+        let mtkMesh = try! MTKMesh(mesh: mesh, device: device)
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setVertexBytes(&mvpMatrix,
+                                     length: MemoryLayout<float4x4>.stride,
+                                     index: 1)
+        renderEncoder.setVertexBytes(&modelMatrix,
+                                     length: MemoryLayout<float4x4>.stride,
+                                     index: 2)
+        renderEncoder.setVertexBuffer(mtkMesh.vertexBuffers[0].buffer,
+                                      offset: 0,
+                                      index: 0)
+
+        renderEncoder.setFragmentTexture(texture, index: 0)
+        renderEncoder.setFragmentSamplerState(samplerState, index: 0)
+
+        var t = time
+        renderEncoder.setFragmentBytes(&t,
+                                       length: MemoryLayout<Float>.stride,
+                                       index: 0)
+        var d = delta
+        renderEncoder.setFragmentBytes(&d,
+                                       length: MemoryLayout<Float>.stride,
+                                       index: 1)
+        var e = QualityManager.shared.exposure
+        renderEncoder.setFragmentBytes(&e,
+                                       length: MemoryLayout<Float>.stride,
+                                       index: 2)
+
+        guard let submesh = mtkMesh.submeshes.first else { return }
+        renderEncoder.drawIndexedPrimitives(type: .triangle,
+                                            indexCount: submesh.indexCount,
+                                            indexType: submesh.indexType,
+                                            indexBuffer: submesh.indexBuffer.buffer,
+                                            indexBufferOffset: submesh.indexBuffer.offset)
+    }
+
+    // MARK: - Helpers
+
+    private static func makePipelineState(device: MTLDevice) -> MTLRenderPipelineState {
+        let library = device.makeDefaultLibrary()!
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.sampleCount = 4
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "vertex_main")
+        descriptor.fragmentFunction = library.makeFunction(name: "fragment_sun")
+        descriptor.vertexDescriptor = makeVertexDescriptor()
+        return try! device.makeRenderPipelineState(descriptor: descriptor)
+    }
+
+    private static func makeVertexDescriptor() -> MTLVertexDescriptor {
+        let vertexDescriptor = MTLVertexDescriptor()
+        vertexDescriptor.attributes[0].format = .float3
+        vertexDescriptor.attributes[0].offset = 0
+        vertexDescriptor.attributes[0].bufferIndex = 0
+        vertexDescriptor.attributes[1].format = .float3
+        vertexDescriptor.attributes[1].offset = MemoryLayout<Float>.stride * 3
+        vertexDescriptor.attributes[1].bufferIndex = 0
+        vertexDescriptor.attributes[2].format = .float2
+        vertexDescriptor.attributes[2].offset = MemoryLayout<Float>.stride * 6
+        vertexDescriptor.attributes[2].bufferIndex = 0
+        vertexDescriptor.layouts[0].stride = MemoryLayout<Float>.stride * 8
+        return vertexDescriptor
+    }
+
+    private static func makeSamplerState(device: MTLDevice) -> MTLSamplerState {
+        let samplerDescriptor = MTLSamplerDescriptor()
+        samplerDescriptor.sAddressMode = .clampToEdge
+        samplerDescriptor.tAddressMode = .clampToEdge
+        samplerDescriptor.minFilter = .linear
+        samplerDescriptor.magFilter = .linear
+        samplerDescriptor.mipFilter = .linear
+        return device.makeSamplerState(descriptor: samplerDescriptor)!
+    }
+
+    private static func createTexturedSphere(device: MTLDevice,
+                                             radius: Float,
+                                             textureName: String) -> MDLMesh {
+        let allocator = MTKMeshBufferAllocator(device: device)
+        let mdlMesh = MDLMesh(
+            sphereWithExtent: [radius * 2, radius * 2, radius * 2],
+            segments: [20, 20],
+            inwardNormals: false,
+            geometryType: .triangles,
+            allocator: allocator
+        )
+        let vertexDescriptor = MTKModelIOVertexDescriptorFromMetal(makeVertexDescriptor())
+        (vertexDescriptor.attributes[0] as! MDLVertexAttribute).name = MDLVertexAttributePosition
+        (vertexDescriptor.attributes[1] as! MDLVertexAttribute).name = MDLVertexAttributeNormal
+        (vertexDescriptor.attributes[2] as! MDLVertexAttribute).name = MDLVertexAttributeTextureCoordinate
+        mdlMesh.vertexDescriptor = vertexDescriptor
+        return mdlMesh
+    }
+
+    private static func loadTexture(device: MTLDevice, name: String) -> MTLTexture {
+        let loader = MTKTextureLoader(device: device)
+        let options: [MTKTextureLoader.Option: Any] = [
+            .origin: MTKTextureLoader.Origin.topLeft.rawValue,
+            .generateMipmaps: true
+        ]
+        let url = Bundle.main.url(forResource: name, withExtension: "png")!
+        return try! loader.newTexture(URL: url, options: options)
+    }
+}
+


### PR DESCRIPTION
Resolves #66
## Summary
- add `SunRenderer` with procedural photosphere and screen-space tracking
- exclude the Sun from `PlanetsRenderer` and expose current simulation time
- integrate Sun renderer into `MetalRenderer` for rendering, labels, and camera follow

## Testing
- `xcodebuild -scheme OptiUniverse build` *(fails: command not found)*
- `xcodebuild test -scheme OptiUniverseTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4589762b08327817a1e94ea596b68