### PR TITLE
Fix 3D texture loading crash

### DIFF
--- a/OptiUniverse/Renderers/SunRenderer.swift
+++ b/OptiUniverse/Renderers/SunRenderer.swift
@@ -229,7 +229,12 @@ final class SunRenderer {
         desc.width = width
         desc.height = height
         desc.depth = depth
-        desc.storageMode = .private
+        // The texture data is uploaded from the CPU, therefore the storage
+        // mode must allow CPU access. Using `.private` causes a runtime crash
+        // when calling `replaceRegion` (CPU access is disallowed). `.shared`
+        // lets us populate the texture once on load while still keeping it
+        // GPU-accessible.
+        desc.storageMode = .shared
         desc.usage = [.shaderRead]
         let texture = device.makeTexture(descriptor: desc)!
 


### PR DESCRIPTION
## Summary
- Avoid crash when uploading 3D texture data by using `.shared` storage mode instead of `.private`

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c51cb8952c8327a9d15d35bf8b3daa