### PR TITLE
Fix corona radial mapping to prevent square artifact

### DIFF
--- a/OptiUniverse/Shaders/CoronaBillboard.metal
+++ b/OptiUniverse/Shaders/CoronaBillboard.metal
@@ -29,10 +29,11 @@ fragment float4 corona_fragment(VertexOut in              [[stage_in]],
                                 texture2d<float> coronaGradient [[texture(0)]],
                                 texture2d<float> coronaNoise [[texture(1)]],
                                 sampler samp [[sampler(0)]]) {
-    // Compute radial distance from the quad center to ensure a circular
-    // falloff instead of sampling the gradient's square UV directly.
-    float2 d = in.uv - float2(0.5, 0.5);
-    float r = min(length(d), 1.0);
+    // Compute radial distance from the quad centre. `in.uv` ranges from
+    // 0..1 so distances are in 0..0.707; scale by 2 so the gradient hits
+    // zero at the edges of the quad, preventing a square-shaped corona.
+    float2 d = in.uv - float2(0.5);
+    float r = min(length(d) * 2.0, 1.0);
     float grad = coronaGradient.sample(samp, float2(r, 0.5)).r;
 
     // Noise introduces subtle flicker but is masked by the radial gradient.


### PR DESCRIPTION
## Summary
- Adjust corona billboard shader to compute radial distance in normalized coordinates, eliminating square-shaped glow edges

## Testing
- `xcodebuild build -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*
- `xcodebuild test -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5527d8d0883278fe05ae4a741d4fa