### PR TITLE
feat: add animated prominences

### DIFF
--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominencesRenderer: ProminencesRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominencesRenderer = ProminencesRenderer(device: device, sunRadius: sunRenderer.radius)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -166,6 +168,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
         // First pass: render scene to MSAA texture and resolve to HDR texture
         guard let geometryCommandBuffer = commandQueue.makeCommandBuffer() else { return }
+        prominencesRenderer.update(commandBuffer: geometryCommandBuffer, time: time, delta: delta)
         let hdrDescriptor = MTLRenderPassDescriptor()
         hdrDescriptor.colorAttachments[0].texture = msaaColorTexture
         hdrDescriptor.colorAttachments[0].resolveTexture = hdrTexture
@@ -187,6 +190,9 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                               viewMatrix: viewMatrix,
                               projectionMatrix: projectionMatrix,
                               viewportSize: metalView.bounds.size)
+
+        var mvpProm = projectionMatrix * viewMatrix * sunRenderer.modelMatrix
+        prominencesRenderer.draw(with: renderEncoder, mvpMatrix: mvpProm, time: time)
 
         if let sunWorld = sunRenderer.worldPosition {
             coronaRenderer.render(with: renderEncoder,

--- a/OptiUniverse/Renderers/ProminencesRenderer.swift
+++ b/OptiUniverse/Renderers/ProminencesRenderer.swift
@@ -102,9 +102,17 @@ final class ProminencesRenderer {
         encoder.setBytes(&t, length: MemoryLayout<Float>.stride, index: 4)
         var d = delta
         encoder.setBytes(&d, length: MemoryLayout<Float>.stride, index: 5)
-        let threads = MTLSize(width: particleCount, height: 1, depth: 1)
-        let threadgroupSize = MTLSize(width: min(computePipeline.maxTotalThreadsPerThreadgroup, particleCount), height: 1, depth: 1)
-        encoder.dispatchThreads(threads, threadsPerThreadgroup: threadgroupSize)
+        // Some devices do not support non-uniform threadgroup sizes when using
+        // `dispatchThreads`, which was triggering validation errors on the
+        // simulator. To ensure wide compatibility we round the total particle
+        // count up to whole threadgroups and use `dispatchThreadgroups`
+        // instead.
+        let threadsPerGroupWidth = min(computePipeline.maxTotalThreadsPerThreadgroup, particleCount)
+        let threadsPerThreadgroup = MTLSize(width: threadsPerGroupWidth, height: 1, depth: 1)
+        let threadgroups = MTLSize(width: (particleCount + threadsPerGroupWidth - 1) / threadsPerGroupWidth,
+                                   height: 1,
+                                   depth: 1)
+        encoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerThreadgroup)
         encoder.endEncoding()
     }
 

--- a/OptiUniverse/Renderers/ProminencesRenderer.swift
+++ b/OptiUniverse/Renderers/ProminencesRenderer.swift
@@ -1,0 +1,134 @@
+import Foundation
+import MetalKit
+import simd
+
+struct ProminenceParticle {
+    var position: SIMD3<Float>
+    var angle: Float
+    var life: Float
+}
+
+final class ProminencesRenderer {
+    private let device: MTLDevice
+    private let computePipeline: MTLComputePipelineState
+    private let renderPipeline: MTLRenderPipelineState
+    private let sampler: MTLSamplerState
+    private let particleBuffer: MTLBuffer
+    private let particleCount: Int
+    private let arcHeight: Float = 0.3
+    private let lifetime: Float = 4.0
+    private let sunRadius: Float
+    private var flipbook: MTLTexture
+    private let frameCount: Int
+    private let fps: Float
+
+    init(device: MTLDevice, sunRadius: Float, particleCount: Int = 512) {
+        self.device = device
+        self.sunRadius = sunRadius
+        self.particleCount = particleCount
+
+        let library = device.makeDefaultLibrary()!
+        let computeFunction = library.makeFunction(name: "updateProminenceParticles")!
+        computePipeline = try! device.makeComputePipelineState(function: computeFunction)
+
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.sampleCount = 4
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "prominence_vertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "prominence_fragment")
+        let blend = descriptor.colorAttachments[0]!
+        blend.isBlendingEnabled = true
+        blend.rgbBlendOperation = .add
+        blend.alphaBlendOperation = .add
+        blend.sourceRGBBlendFactor = .one
+        blend.destinationRGBBlendFactor = .one
+        blend.sourceAlphaBlendFactor = .one
+        blend.destinationAlphaBlendFactor = .one
+        renderPipeline = try! device.makeRenderPipelineState(descriptor: descriptor)
+
+        let samplerDesc = MTLSamplerDescriptor()
+        samplerDesc.minFilter = .linear
+        samplerDesc.magFilter = .linear
+        samplerDesc.mipFilter = .linear
+        samplerDesc.sAddressMode = .clampToEdge
+        samplerDesc.tAddressMode = .clampToEdge
+        sampler = device.makeSamplerState(descriptor: samplerDesc)!
+
+        let loader = MTKTextureLoader(device: device)
+        let url = Bundle.main.url(forResource: "prominence_flipbook", withExtension: "png", subdirectory: "Assets/Flipbooks")
+            ?? Bundle.main.url(forResource: "prominence_flipbook", withExtension: "png")
+        flipbook = try! loader.newTexture(URL: url!, options: [.origin: MTKTextureLoader.Origin.topLeft.rawValue])
+
+        let timingURL = Bundle.main.url(forResource: "prominence_flipbook_timing", withExtension: "txt", subdirectory: "Assets/Flipbooks")
+            ?? Bundle.main.url(forResource: "prominence_flipbook_timing", withExtension: "txt")
+        var tmpFrameCount = 16
+        var tmpFPS: Float = 13.5
+        if let url = timingURL, let text = try? String(contentsOf: url) {
+            if let line = text.split(separator: "\n").first(where: { $0.hasPrefix("Frames") }),
+               let value = line.split(separator: ":").last,
+               let parsed = Int(value.trimmingCharacters(in: .whitespaces)) {
+                tmpFrameCount = parsed
+            }
+            if let line = text.split(separator: "\n").first(where: { $0.contains("float fps") }),
+               let value = line.split(separator: "=").last?.split(separator: ";").first,
+               let parsed = Float(value.trimmingCharacters(in: .whitespaces)) {
+                tmpFPS = parsed
+            }
+        }
+        frameCount = tmpFrameCount
+        fps = tmpFPS
+
+        particleBuffer = device.makeBuffer(length: MemoryLayout<ProminenceParticle>.stride * particleCount, options: [])!
+        let ptr = particleBuffer.contents().bindMemory(to: ProminenceParticle.self, capacity: particleCount)
+        for i in 0..<particleCount {
+            let angle = Float(i) / Float(particleCount) * (2 * .pi)
+            let life = Float.random(in: 0..<lifetime)
+            ptr[i] = ProminenceParticle(position: SIMD3<Float>(cos(angle), 0, sin(angle)), angle: angle, life: life)
+        }
+    }
+
+    func update(commandBuffer: MTLCommandBuffer, time: Float, delta: Float) {
+        let encoder = commandBuffer.makeComputeCommandEncoder()!
+        encoder.setComputePipelineState(computePipeline)
+        encoder.setBuffer(particleBuffer, offset: 0, index: 0)
+        var count = UInt32(particleCount)
+        encoder.setBytes(&count, length: MemoryLayout<UInt32>.stride, index: 1)
+        var height = arcHeight
+        encoder.setBytes(&height, length: MemoryLayout<Float>.stride, index: 2)
+        var life = lifetime
+        encoder.setBytes(&life, length: MemoryLayout<Float>.stride, index: 3)
+        var t = time
+        encoder.setBytes(&t, length: MemoryLayout<Float>.stride, index: 4)
+        var d = delta
+        encoder.setBytes(&d, length: MemoryLayout<Float>.stride, index: 5)
+        let threads = MTLSize(width: particleCount, height: 1, depth: 1)
+        let threadgroupSize = MTLSize(width: min(computePipeline.maxTotalThreadsPerThreadgroup, particleCount), height: 1, depth: 1)
+        encoder.dispatchThreads(threads, threadsPerThreadgroup: threadgroupSize)
+        encoder.endEncoding()
+    }
+
+    func draw(with renderEncoder: MTLRenderCommandEncoder, mvpMatrix: float4x4, time: Float) {
+        renderEncoder.setRenderPipelineState(renderPipeline)
+        renderEncoder.setVertexBuffer(particleBuffer, offset: 0, index: 0)
+        var mvp = mvpMatrix
+        renderEncoder.setVertexBytes(&mvp, length: MemoryLayout<float4x4>.stride, index: 1)
+        var radius = sunRadius
+        renderEncoder.setVertexBytes(&radius, length: MemoryLayout<Float>.stride, index: 2)
+        var life = lifetime
+        renderEncoder.setVertexBytes(&life, length: MemoryLayout<Float>.stride, index: 3)
+
+        renderEncoder.setFragmentTexture(flipbook, index: 0)
+        renderEncoder.setFragmentSamplerState(sampler, index: 0)
+        renderEncoder.setFragmentBytes(&life, length: MemoryLayout<Float>.stride, index: 0)
+        var t = time
+        renderEncoder.setFragmentBytes(&t, length: MemoryLayout<Float>.stride, index: 1)
+        var frames = Int32(frameCount)
+        renderEncoder.setFragmentBytes(&frames, length: MemoryLayout<Int32>.stride, index: 2)
+        var f = fps
+        renderEncoder.setFragmentBytes(&f, length: MemoryLayout<Float>.stride, index: 3)
+
+        renderEncoder.drawPrimitives(type: .point, vertexStart: 0, vertexCount: particleCount)
+    }
+}
+

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -10,29 +10,42 @@ struct ProminenceParticle {
 struct VertexOut {
     float4 position [[position]];
     float  life;
+    float  angle;
     float  pointSize [[point_size]];
 };
 
 vertex VertexOut prominence_vertex(
     const device ProminenceParticle *particles [[buffer(0)]],
     constant float4x4 &mvpMatrix [[buffer(1)]],
-    constant float    &lifetime  [[buffer(2)]],
+    constant float    &sunRadius [[buffer(2)]],
+    constant float    &lifetime  [[buffer(3)]],
     uint id [[vertex_id]]) {
 
     ProminenceParticle p = particles[id];
     VertexOut out;
-    out.position = mvpMatrix * float4(p.position, 1.0);
+    out.position = mvpMatrix * float4(p.position * sunRadius, 1.0);
     out.life = p.life;
+    out.angle = p.angle;
     float age = 1.0 - p.life / lifetime;
-    out.pointSize = 1.0 + (1.0 - age) * 2.0;
+    out.pointSize = 20.0 + (1.0 - age) * 40.0;
     return out;
 }
 
 fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
+                                    float2 pointCoord [[point_coord]],
+                                    constant float &lifetime [[buffer(0)]],
+                                    constant float &time [[buffer(1)]],
+                                    constant int   &frameCount [[buffer(2)]],
+                                    constant float &fps [[buffer(3)]],
+                                    texture2d<float> flipbook [[texture(0)]],
+                                    sampler samp [[sampler(0)]]) {
     float age = 1.0 - in.life / lifetime;
     float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
+    float N = float(frameCount);
+    float frame = floor(fmod(time * fps + in.angle / (2.0 * M_PI_F) * N, N));
+    float vStep = 1.0 / N;
+    float2 uv = float2(pointCoord.x, pointCoord.y / N + frame * vStep);
+    float4 color = flipbook.sample(samp, uv);
+    return float4(color.rgb * alpha, color.a * alpha);
 }
 


### PR DESCRIPTION
## Summary
- render flipbook-based solar prominences around the limb
- parse flipbook timing data for frame count and fps
- integrate prominence pass into main renderer

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b35db5048327aaea5872a9a68eba