### PR TITLE
Add animated solar prominence flipbook rendering

### DIFF
--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominencesRenderer: ProminencesRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominencesRenderer = ProminencesRenderer(device: device)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -166,6 +168,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
         // First pass: render scene to MSAA texture and resolve to HDR texture
         guard let geometryCommandBuffer = commandQueue.makeCommandBuffer() else { return }
+        prominencesRenderer.update(commandBuffer: geometryCommandBuffer, time: time, delta: delta)
         let hdrDescriptor = MTLRenderPassDescriptor()
         hdrDescriptor.colorAttachments[0].texture = msaaColorTexture
         hdrDescriptor.colorAttachments[0].resolveTexture = hdrTexture
@@ -196,6 +199,11 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                   modelMatrix: sunRenderer.modelMatrix,
                                   sunWorldPosition: sunWorld,
                                   cameraPosition: cameraPosition)
+            prominencesRenderer.render(with: renderEncoder,
+                                       viewMatrix: viewMatrix,
+                                       projectionMatrix: projectionMatrix,
+                                       modelMatrix: sunRenderer.modelMatrix,
+                                       time: time)
         }
 
         // Render the remaining planets.

--- a/OptiUniverse/Renderers/ProminencesRenderer.swift
+++ b/OptiUniverse/Renderers/ProminencesRenderer.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MetalKit
+import simd
+
+struct ProminenceParticle {
+    var position: SIMD3<Float>
+    var angle: Float
+    var life: Float
+    var pad: Float = 0
+}
+
+final class ProminencesRenderer {
+    private let device: MTLDevice
+    private let computePipeline: MTLComputePipelineState
+    private let renderPipeline: MTLRenderPipelineState
+    private let sampler: MTLSamplerState
+    private let texture: MTLTexture
+    private let particleCount: Int
+    private var particleBuffer: MTLBuffer
+
+    private var lifetime: Float = 5.0
+    private var arcHeight: Float = 0.2
+
+    init(device: MTLDevice, particleCount: Int = 512) {
+        self.device = device
+        self.particleCount = particleCount
+        let library = device.makeDefaultLibrary()!
+        computePipeline = try! device.makeComputePipelineState(function: library.makeFunction(name: "updateProminenceParticles")!)
+
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.sampleCount = 4
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "prominence_vertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "prominence_fragment")
+        let blend = descriptor.colorAttachments[0]!
+        blend.isBlendingEnabled = true
+        blend.rgbBlendOperation = .add
+        blend.alphaBlendOperation = .add
+        blend.sourceRGBBlendFactor = .one
+        blend.destinationRGBBlendFactor = .one
+        blend.sourceAlphaBlendFactor = .one
+        blend.destinationAlphaBlendFactor = .one
+        renderPipeline = try! device.makeRenderPipelineState(descriptor: descriptor)
+
+        let samplerDesc = MTLSamplerDescriptor()
+        samplerDesc.minFilter = .linear
+        samplerDesc.magFilter = .linear
+        samplerDesc.mipFilter = .linear
+        samplerDesc.sAddressMode = .clampToEdge
+        samplerDesc.tAddressMode = .clampToEdge
+        sampler = device.makeSamplerState(descriptor: samplerDesc)!
+
+        let loader = MTKTextureLoader(device: device)
+        let url = Bundle.main.url(forResource: "prominence_flipbook", withExtension: "png")!
+        texture = try! loader.newTexture(URL: url, options: [.origin: MTKTextureLoader.Origin.topLeft.rawValue])
+
+        particleBuffer = device.makeBuffer(length: MemoryLayout<ProminenceParticle>.stride * particleCount, options: [])!
+        resetParticles()
+    }
+
+    private func resetParticles() {
+        let pointer = particleBuffer.contents().bindMemory(to: ProminenceParticle.self, capacity: particleCount)
+        for i in 0..<particleCount {
+            pointer[i] = ProminenceParticle(position: SIMD3<Float>(repeating: 0), angle: 0, life: 0, pad: 0)
+        }
+    }
+
+    func update(commandBuffer: MTLCommandBuffer, time: Float, delta: Float) {
+        guard let computeEncoder = commandBuffer.makeComputeCommandEncoder() else { return }
+        computeEncoder.setComputePipelineState(computePipeline)
+        computeEncoder.setBuffer(particleBuffer, offset: 0, index: 0)
+        var count = UInt32(particleCount)
+        var arc = arcHeight
+        var life = lifetime
+        var t = time
+        var d = delta
+        computeEncoder.setBytes(&count, length: MemoryLayout<UInt32>.stride, index: 1)
+        computeEncoder.setBytes(&arc, length: MemoryLayout<Float>.stride, index: 2)
+        computeEncoder.setBytes(&life, length: MemoryLayout<Float>.stride, index: 3)
+        computeEncoder.setBytes(&t, length: MemoryLayout<Float>.stride, index: 4)
+        computeEncoder.setBytes(&d, length: MemoryLayout<Float>.stride, index: 5)
+        let threads = MTLSize(width: particleCount, height: 1, depth: 1)
+        let tgWidth = min(computePipeline.maxTotalThreadsPerThreadgroup, particleCount)
+        let tg = MTLSize(width: tgWidth, height: 1, depth: 1)
+        computeEncoder.dispatchThreads(threads, threadsPerThreadgroup: tg)
+        computeEncoder.endEncoding()
+    }
+
+    func render(with renderEncoder: MTLRenderCommandEncoder,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4,
+                modelMatrix: float4x4,
+                time: Float) {
+        var mvp = projectionMatrix * viewMatrix * modelMatrix
+        renderEncoder.setRenderPipelineState(renderPipeline)
+        renderEncoder.setVertexBuffer(particleBuffer, offset: 0, index: 0)
+        renderEncoder.setVertexBytes(&mvp, length: MemoryLayout<float4x4>.stride, index: 1)
+        var life = lifetime
+        renderEncoder.setVertexBytes(&life, length: MemoryLayout<Float>.stride, index: 2)
+        renderEncoder.setFragmentBytes(&life, length: MemoryLayout<Float>.stride, index: 0)
+        var t = time
+        renderEncoder.setFragmentBytes(&t, length: MemoryLayout<Float>.stride, index: 1)
+        renderEncoder.setFragmentTexture(texture, index: 0)
+        renderEncoder.setFragmentSamplerState(sampler, index: 0)
+        renderEncoder.drawPrimitives(type: .point, vertexStart: 0, vertexCount: particleCount)
+    }
+}

--- a/OptiUniverse/Shaders/Prominences.compute.metal
+++ b/OptiUniverse/Shaders/Prominences.compute.metal
@@ -5,6 +5,7 @@ struct ProminenceParticle {
     float3 position;
     float  angle;   // angle around the sun's limb
     float  life;    // remaining life time
+    float  pad;     // padding for 16-byte alignment
 };
 
 // Simple deterministic pseudo-random generator

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -5,6 +5,7 @@ struct ProminenceParticle {
     float3 position;
     float  angle;
     float  life;
+    float  pad;  // padding for 16-byte alignment
 };
 
 struct VertexOut {
@@ -29,10 +30,19 @@ vertex VertexOut prominence_vertex(
 }
 
 fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
+                                    float2 pointCoord [[point_coord]],
+                                    constant float &lifetime [[buffer(0)]],
+                                    constant float &time [[buffer(1)]],
+                                    texture2d<float> flipbook [[texture(0)]],
+                                    sampler samp [[sampler(0)]]) {
+    constexpr int N = 16;
+    constexpr float fps = 13.5;
+    float frame = floor(fmod(time * fps, float(N)));
+    float vStep = 1.0 / float(N);
+    float2 uv = float2(pointCoord.x, pointCoord.y / float(N) + frame * vStep);
+    float4 tex = flipbook.sample(samp, uv);
     float age = 1.0 - in.life / lifetime;
-    float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
+    float alpha = tex.a * (1.0 - age);
+    return float4(tex.rgb * alpha, alpha); // Additive blending expected
 }
 


### PR DESCRIPTION
## Summary
- Render compute-driven prominence particles as billboards
- Animate prominence sprites with flipbook UV indexing
- Wire prominences renderer into main Metal renderer

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b35db5048327aaea5872a9a68eba