### PR TITLE
Add solar prominence renderer with flipbook animation

### DIFF
--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominenceRenderer: ProminenceRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominenceRenderer = ProminenceRenderer(device: device, sunRadius: sunRenderer.radius)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -166,6 +168,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
         // First pass: render scene to MSAA texture and resolve to HDR texture
         guard let geometryCommandBuffer = commandQueue.makeCommandBuffer() else { return }
+        prominenceRenderer.update(commandBuffer: geometryCommandBuffer, delta: delta, time: time)
         let hdrDescriptor = MTLRenderPassDescriptor()
         hdrDescriptor.colorAttachments[0].texture = msaaColorTexture
         hdrDescriptor.colorAttachments[0].resolveTexture = hdrTexture
@@ -196,6 +199,12 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                   modelMatrix: sunRenderer.modelMatrix,
                                   sunWorldPosition: sunWorld,
                                   cameraPosition: cameraPosition)
+
+            prominenceRenderer.render(with: renderEncoder,
+                                      viewMatrix: viewMatrix,
+                                      projectionMatrix: projectionMatrix,
+                                      sunModelMatrix: sunRenderer.modelMatrix,
+                                      time: time)
         }
 
         // Render the remaining planets.

--- a/OptiUniverse/Renderers/ProminenceRenderer.swift
+++ b/OptiUniverse/Renderers/ProminenceRenderer.swift
@@ -1,0 +1,180 @@
+//
+//  ProminenceRenderer.swift
+//  OptiUniverse
+//
+//  Renders animated solar prominences along the Sun's limb using a
+//  flipbook texture atlas. Particle positions are updated on the GPU
+//  via `updateProminenceParticles` compute kernel and rendered as point
+//  sprites that billboard towards the camera. The UV coordinates are
+//  animated according to the timing guide in
+//  `Assets/Flipbooks/prominence_flipbook_timing.txt`.
+//
+
+import Foundation
+import MetalKit
+import simd
+
+/// CPU-side mirror of the Metal `ProminenceParticle` struct.
+/// Memory layout must match the shader definition.
+private struct ProminenceParticle {
+    var position: SIMD3<Float> = .zero
+    var angle: Float = 0
+    var life: Float = 0
+    var padding: Float = 0 // 16-byte alignment
+}
+
+/// Renderer responsible for updating and drawing solar prominences.
+final class ProminenceRenderer {
+    private let device: MTLDevice
+    private let computePipeline: MTLComputePipelineState
+    private let renderPipeline: MTLRenderPipelineState
+    private let sampler: MTLSamplerState
+    private let texture: MTLTexture
+
+    private var particles: MTLBuffer
+    private let particleCount: Int = 32
+    private let lifetime: Float = 5.0
+    private let arcHeight: Float = 0.3
+    private let sunRadius: Float
+
+    private let frameCount: UInt32
+    private let fps: Float
+
+    init(device: MTLDevice, sunRadius: Float) {
+        self.device = device
+        self.sunRadius = sunRadius
+
+        let library = device.makeDefaultLibrary()!
+        let computeFunc = library.makeFunction(name: "updateProminenceParticles")!
+        computePipeline = try! device.makeComputePipelineState(function: computeFunc)
+
+        let renderDesc = MTLRenderPipelineDescriptor()
+        renderDesc.colorAttachments[0].pixelFormat = .rgba16Float
+        renderDesc.sampleCount = 4
+        renderDesc.depthAttachmentPixelFormat = .depth32Float
+        renderDesc.vertexFunction = library.makeFunction(name: "prominence_vertex")
+        renderDesc.fragmentFunction = library.makeFunction(name: "prominence_fragment")
+        let blend = renderDesc.colorAttachments[0]!
+        blend.isBlendingEnabled = true
+        blend.rgbBlendOperation = .add
+        blend.alphaBlendOperation = .add
+        blend.sourceRGBBlendFactor = .one
+        blend.sourceAlphaBlendFactor = .one
+        blend.destinationRGBBlendFactor = .one
+        blend.destinationAlphaBlendFactor = .one
+        renderPipeline = try! device.makeRenderPipelineState(descriptor: renderDesc)
+
+        let samplerDesc = MTLSamplerDescriptor()
+        samplerDesc.sAddressMode = .clampToEdge
+        samplerDesc.tAddressMode = .clampToEdge
+        samplerDesc.minFilter = .linear
+        samplerDesc.magFilter = .linear
+        samplerDesc.mipFilter = .linear
+        sampler = device.makeSamplerState(descriptor: samplerDesc)!
+
+        texture = ProminenceRenderer.loadTexture(device: device)
+        let timing = ProminenceRenderer.loadTiming()
+        frameCount = UInt32(timing.frames)
+        fps = timing.fps
+
+        particles = device.makeBuffer(length: MemoryLayout<ProminenceParticle>.stride * particleCount,
+                                      options: .storageModeShared)!
+        // Initialise particles with zero life so compute kernel respawns them.
+        let ptr = particles.contents().bindMemory(to: ProminenceParticle.self, capacity: particleCount)
+        for i in 0..<particleCount {
+            ptr[i] = ProminenceParticle()
+        }
+    }
+
+    /// Updates particle positions using the compute kernel.
+    func update(commandBuffer: MTLCommandBuffer, delta: Float, time: Float) {
+        guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
+        encoder.setComputePipelineState(computePipeline)
+        encoder.setBuffer(particles, offset: 0, index: 0)
+        var count = UInt32(particleCount)
+        encoder.setBytes(&count, length: MemoryLayout<UInt32>.stride, index: 1)
+        var height = arcHeight
+        encoder.setBytes(&height, length: MemoryLayout<Float>.stride, index: 2)
+        var life = lifetime
+        encoder.setBytes(&life, length: MemoryLayout<Float>.stride, index: 3)
+        var t = time
+        encoder.setBytes(&t, length: MemoryLayout<Float>.stride, index: 4)
+        var dt = delta
+        encoder.setBytes(&dt, length: MemoryLayout<Float>.stride, index: 5)
+
+        let threads = MTLSize(width: particleCount, height: 1, depth: 1)
+        let w = computePipeline.maxTotalThreadsPerThreadgroup
+        let tg = MTLSize(width: min(particleCount, w), height: 1, depth: 1)
+        encoder.dispatchThreads(threads, threadsPerThreadgroup: tg)
+        encoder.endEncoding()
+    }
+
+    /// Renders the current particles as billboards.
+    func render(with renderEncoder: MTLRenderCommandEncoder,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4,
+                sunModelMatrix: float4x4,
+                time: Float) {
+        var mvp = projectionMatrix * viewMatrix * sunModelMatrix
+        renderEncoder.setRenderPipelineState(renderPipeline)
+        renderEncoder.setVertexBuffer(particles, offset: 0, index: 0)
+        renderEncoder.setVertexBytes(&mvp, length: MemoryLayout<float4x4>.stride, index: 1)
+        var life = lifetime
+        renderEncoder.setVertexBytes(&life, length: MemoryLayout<Float>.stride, index: 2)
+        var radius = sunRadius
+        renderEncoder.setVertexBytes(&radius, length: MemoryLayout<Float>.stride, index: 3)
+
+        renderEncoder.setFragmentBytes(&life, length: MemoryLayout<Float>.stride, index: 0)
+        var t = time
+        renderEncoder.setFragmentBytes(&t, length: MemoryLayout<Float>.stride, index: 1)
+        var frames = frameCount
+        renderEncoder.setFragmentBytes(&frames, length: MemoryLayout<UInt32>.stride, index: 2)
+        var rate = fps
+        renderEncoder.setFragmentBytes(&rate, length: MemoryLayout<Float>.stride, index: 3)
+        renderEncoder.setFragmentTexture(texture, index: 0)
+        renderEncoder.setFragmentSamplerState(sampler, index: 0)
+
+        renderEncoder.drawPrimitives(type: .point, vertexStart: 0, vertexCount: particleCount)
+    }
+
+    // MARK: - Helpers
+
+    private static func loadTexture(device: MTLDevice) -> MTLTexture {
+        let loader = MTKTextureLoader(device: device)
+        let options: [MTKTextureLoader.Option: Any] = [
+            .origin: MTKTextureLoader.Origin.topLeft.rawValue,
+            .generateMipmaps: true
+        ]
+        let url = Bundle.main.url(forResource: "Flipbooks/prominence_flipbook", withExtension: "png")!
+        return try! loader.newTexture(URL: url, options: options)
+    }
+
+    /// Parses the timing guide to extract frame count and FPS.
+    private static func loadTiming() -> (frames: Int, fps: Float) {
+        guard let url = Bundle.main.url(forResource: "Flipbooks/prominence_flipbook_timing",
+                                        withExtension: "txt"),
+              let text = try? String(contentsOf: url) else {
+            return (16, 13.5)
+        }
+        var frames = 16
+        var fps: Float = 13.5
+        for line in text.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("Frames:") {
+                let comps = trimmed.split(separator: ":")
+                if comps.count > 1 { frames = Int(comps[1].trimmingCharacters(in: .whitespaces)) ?? frames }
+            } else if trimmed.hasPrefix("Playback:") {
+                // Extract numbers such as "12-15 FPS" and average them
+                let numbers = trimmed.components(separatedBy: CharacterSet.decimalDigits.inverted)
+                    .compactMap { Int($0) }
+                if numbers.count >= 2 {
+                    fps = Float(numbers[0] + numbers[1]) / 2.0
+                } else if let first = numbers.first {
+                    fps = Float(first)
+                }
+            }
+        }
+        return (frames, fps)
+    }
+}
+

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -10,6 +10,7 @@ struct ProminenceParticle {
 struct VertexOut {
     float4 position [[position]];
     float  life;
+    uint   id [[flat]];
     float  pointSize [[point_size]];
 };
 
@@ -17,22 +18,35 @@ vertex VertexOut prominence_vertex(
     const device ProminenceParticle *particles [[buffer(0)]],
     constant float4x4 &mvpMatrix [[buffer(1)]],
     constant float    &lifetime  [[buffer(2)]],
+    constant float    &radius    [[buffer(3)]],
     uint id [[vertex_id]]) {
 
     ProminenceParticle p = particles[id];
     VertexOut out;
-    out.position = mvpMatrix * float4(p.position, 1.0);
+    float3 scaled = p.position * radius;
+    out.position = mvpMatrix * float4(scaled, 1.0);
     out.life = p.life;
+    out.id = id;
     float age = 1.0 - p.life / lifetime;
-    out.pointSize = 1.0 + (1.0 - age) * 2.0;
+    out.pointSize = 128.0 + (1.0 - age) * 64.0;
     return out;
 }
 
 fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
+                                    float2 pointCoord [[point_coord]],
+                                    constant float &lifetime [[buffer(0)]],
+                                    constant float &time [[buffer(1)]],
+                                    constant uint  &frameCount [[buffer(2)]],
+                                    constant float &fps [[buffer(3)]],
+                                    texture2d<float> flipbookTex [[texture(0)]],
+                                    sampler flipbookSampler [[sampler(0)]]) {
     float age = 1.0 - in.life / lifetime;
-    float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
+    float frame = floor(fmod(time * fps + float(in.id), float(frameCount)));
+    float vStep = 1.0 / float(frameCount);
+    float2 uv = float2(pointCoord.x, pointCoord.y / float(frameCount) + frame * vStep);
+    float4 tex = flipbookTex.sample(flipbookSampler, uv);
+    float alpha = tex.a * (1.0 - age);
+    float3 color = tex.rgb * alpha;
+    return float4(color, alpha);
 }
 


### PR DESCRIPTION
## Summary
- Render solar prominences as billboard sprites animated from a flipbook atlas
- Parse timing guide to drive UV animation and integrate renderer into main pipeline
- Sample flipbook frames in new prominence shader with additive blending

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b35db5048327aaea5872a9a68eba