### PR TITLE
Add solar prominence flipbook renderer

### DIFF
--- a/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
+++ b/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
@@ -1,16 +1,11 @@
-Prominence Flipbook Timing Guide
-
-Frames: 16
-Resolution per frame: 512x512
-Atlas layout: vertical strip (512 x 8192)
-Playback: 12-15 FPS
-Cycle length: ~1.19 seconds
-
-UV indexing (GLSL-like pseudocode):
------------------------------------
-int N = 16;
-float fps = 13.5;
-float frame = floor(mod(time * fps, float(N)));
-float vStep = 1.0 / float(N);
-vec2 uvAtlas = vec2(uv.x, uv.y / float(N) + frame * vStep);
-vec4 tex = texture(flipbookTex, uvAtlas);
+# frameCount cols rows fps baseIntensity variance seed
+16 1 16 13.5 1.0 0.25 1337
+# entries: angleDeg radiusMul lift scale fpsMul startPhase
+0   1.03  0.02  0.06  1.0  0.0
+45  1.05  0.03  0.08  1.0  0.2
+90  1.08  0.04  0.10  0.9  0.5
+135 1.04  0.03  0.07  1.1  0.7
+180 1.03  0.025 0.05  1.0  0.1
+225 1.05  0.035 0.08  1.2  0.4
+270 1.07  0.04  0.10  0.8  0.6
+315 1.04  0.03  0.07  1.0  0.9

--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominenceRenderer: ProminenceRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominenceRenderer = ProminenceRenderer(device: device, sunRadius: sunRenderer.radius)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -187,6 +189,11 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                               viewMatrix: viewMatrix,
                               projectionMatrix: projectionMatrix,
                               viewportSize: metalView.bounds.size)
+
+        prominenceRenderer.render(with: renderEncoder,
+                                  time: time,
+                                  viewMatrix: viewMatrix,
+                                  projectionMatrix: projectionMatrix)
 
         if let sunWorld = sunRenderer.worldPosition {
             coronaRenderer.render(with: renderEncoder,

--- a/OptiUniverse/Renderers/ProminenceRenderer.swift
+++ b/OptiUniverse/Renderers/ProminenceRenderer.swift
@@ -1,0 +1,197 @@
+import Foundation
+import MetalKit
+import simd
+
+struct ProminenceParams {
+    var time: Float = 0
+    var flipFps: Float = 0
+    var cols: Int32 = 1
+    var rows: Int32 = 1
+    var intensity: Float = 1
+    var hueShift: Float = 0
+    var noiseUV: SIMD2<Float> = SIMD2<Float>(1, 1)
+}
+
+struct ProminenceVertex {
+    var worldPos: SIMD3<Float>
+    var corner: SIMD2<Float>
+    var scale: Float
+    var startPhase: Float
+    var fpsMul: Float
+}
+
+struct CameraData {
+    var viewProj: float4x4
+    var camRight: SIMD3<Float>
+    var pad1: Float = 0
+    var camUp: SIMD3<Float>
+    var pad2: Float = 0
+}
+
+final class ProminenceRenderer {
+    private let device: MTLDevice
+    private let pipelineState: MTLRenderPipelineState
+    private let samplerState: MTLSamplerState
+    private let flipbook: MTLTexture
+    private let noise: MTLTexture
+    private let vertexBuffer: MTLBuffer
+    private var params: ProminenceParams
+    private let vertexCount: Int
+
+    init(device: MTLDevice, sunRadius: Float) {
+        self.device = device
+        self.pipelineState = ProminenceRenderer.makePipelineState(device: device)
+        self.samplerState = ProminenceRenderer.makeSamplerState(device: device)
+        self.flipbook = ProminenceRenderer.loadTexture(device: device, name: "prominence_flipbook")
+        self.noise = ProminenceRenderer.loadTexture(device: device, name: "corona_noise_512")
+        let timing = ProminenceRenderer.loadTiming(device: device,
+                                                   sunRadius: sunRadius)
+        self.vertexBuffer = timing.buffer
+        self.params = timing.params
+        self.vertexCount = timing.vertexCount
+    }
+
+    func render(with renderEncoder: MTLRenderCommandEncoder,
+                time: Float,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4) {
+        var camera = CameraData(viewProj: projectionMatrix * viewMatrix,
+                                camRight: SIMD3<Float>(viewMatrix.columns.0.x,
+                                                       viewMatrix.columns.0.y,
+                                                       viewMatrix.columns.0.z),
+                                camUp: SIMD3<Float>(viewMatrix.columns.1.x,
+                                                    viewMatrix.columns.1.y,
+                                                    viewMatrix.columns.1.z))
+        params.time = time
+
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        renderEncoder.setVertexBytes(&camera, length: MemoryLayout<CameraData>.stride, index: 1)
+        renderEncoder.setVertexBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 2)
+
+        renderEncoder.setFragmentTexture(flipbook, index: 0)
+        renderEncoder.setFragmentTexture(noise, index: 1)
+        renderEncoder.setFragmentSamplerState(samplerState, index: 0)
+        renderEncoder.setFragmentBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 0)
+
+        renderEncoder.drawPrimitives(type: .triangle,
+                                     vertexStart: 0,
+                                     vertexCount: vertexCount)
+    }
+
+    private static func loadTiming(device: MTLDevice,
+                                   sunRadius: Float) -> (buffer: MTLBuffer, params: ProminenceParams, vertexCount: Int) {
+        var params = ProminenceParams()
+        var vertices: [ProminenceVertex] = []
+        if let url = Bundle.main.url(forResource: "prominence_flipbook_timing", withExtension: "txt"),
+           let text = try? String(contentsOf: url) {
+            let lines = text.split(whereSeparator: { $0.isNewline })
+            var dataLines: [Substring] = []
+            for line in lines {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+                dataLines.append(Substring(trimmed))
+            }
+            if dataLines.count > 0 {
+                let header = dataLines[0].split{ $0 == " " }
+                if header.count >= 7 {
+                    params.flipFps = Float(header[3]) ?? 16
+                    params.cols = Int32(header[1]) ?? 1
+                    params.rows = Int32(header[2]) ?? 1
+                    params.intensity = Float(header[4]) ?? 1
+                }
+                for line in dataLines.dropFirst() {
+                    let comps = line.split{ $0 == " " }
+                    if comps.count < 6 { continue }
+                    let angle = (Float(comps[0]) ?? 0) * (.pi / 180)
+                    let radiusMul = Float(comps[1]) ?? 1
+                    let lift = Float(comps[2]) ?? 0
+                    let scale = Float(comps[3]) ?? 0.05
+                    let fpsMul = Float(comps[4]) ?? 1
+                    let startPhase = Float(comps[5]) ?? 0
+
+                    let dir = SIMD3<Float>(cos(angle), 0, sin(angle))
+                    let pos = dir * sunRadius * radiusMul + SIMD3<Float>(0, sunRadius * lift, 0)
+                    let size = scale * sunRadius
+                    let corners: [SIMD2<Float>] = [
+                        SIMD2(-0.5, -0.5), SIMD2( 0.5, -0.5), SIMD2(-0.5,  0.5),
+                        SIMD2( 0.5, -0.5), SIMD2( 0.5,  0.5), SIMD2(-0.5,  0.5)
+                    ]
+                    for corner in corners {
+                        vertices.append(ProminenceVertex(worldPos: pos,
+                                                         corner: corner,
+                                                         scale: size,
+                                                         startPhase: startPhase,
+                                                         fpsMul: fpsMul))
+                    }
+                }
+            }
+        }
+        let buffer = device.makeBuffer(bytes: vertices,
+                                       length: vertices.count * MemoryLayout<ProminenceVertex>.stride,
+                                       options: [])!
+        return (buffer, params, vertices.count)
+    }
+
+    private static func loadTexture(device: MTLDevice, name: String) -> MTLTexture {
+        let loader = MTKTextureLoader(device: device)
+        let options: [MTKTextureLoader.Option: Any] = [
+            .origin: MTKTextureLoader.Origin.topLeft.rawValue,
+            .SRGB: false
+        ]
+        let url = Bundle.main.url(forResource: name, withExtension: "png")!
+        return try! loader.newTexture(URL: url, options: options)
+    }
+
+    private static func makeSamplerState(device: MTLDevice) -> MTLSamplerState {
+        let desc = MTLSamplerDescriptor()
+        desc.minFilter = .linear
+        desc.magFilter = .linear
+        desc.mipFilter = .linear
+        desc.sAddressMode = .clampToEdge
+        desc.tAddressMode = .clampToEdge
+        return device.makeSamplerState(descriptor: desc)!
+    }
+
+    private static func makePipelineState(device: MTLDevice) -> MTLRenderPipelineState {
+        let library = device.makeDefaultLibrary()!
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.sampleCount = 4
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "prom_vertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "prom_fragment")
+        descriptor.vertexDescriptor = makeVertexDescriptor()
+        let blend = descriptor.colorAttachments[0]!
+        blend.isBlendingEnabled = true
+        blend.rgbBlendOperation = .add
+        blend.alphaBlendOperation = .add
+        blend.sourceRGBBlendFactor = .one
+        blend.sourceAlphaBlendFactor = .one
+        blend.destinationRGBBlendFactor = .one
+        blend.destinationAlphaBlendFactor = .one
+        return try! device.makeRenderPipelineState(descriptor: descriptor)
+    }
+
+    private static func makeVertexDescriptor() -> MTLVertexDescriptor {
+        let vd = MTLVertexDescriptor()
+        vd.attributes[0].format = .float3
+        vd.attributes[0].offset = 0
+        vd.attributes[0].bufferIndex = 0
+        vd.attributes[1].format = .float2
+        vd.attributes[1].offset = MemoryLayout<Float>.stride * 3
+        vd.attributes[1].bufferIndex = 0
+        vd.attributes[2].format = .float
+        vd.attributes[2].offset = MemoryLayout<Float>.stride * 5
+        vd.attributes[2].bufferIndex = 0
+        vd.attributes[3].format = .float
+        vd.attributes[3].offset = MemoryLayout<Float>.stride * 6
+        vd.attributes[3].bufferIndex = 0
+        vd.attributes[4].format = .float
+        vd.attributes[4].offset = MemoryLayout<Float>.stride * 7
+        vd.attributes[4].bufferIndex = 0
+        vd.layouts[0].stride = MemoryLayout<ProminenceVertex>.stride
+        return vd
+    }
+}
+

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -1,38 +1,71 @@
 #include <metal_stdlib>
 using namespace metal;
 
-struct ProminenceParticle {
-    float3 position;
-    float  angle;
-    float  life;
+struct VSIn {
+    float3 worldPos;
+    float2 corner;
+    float  scale;
+    float  startPhase;
+    float  fpsMul;
 };
 
-struct VertexOut {
-    float4 position [[position]];
-    float  life;
-    float  pointSize [[point_size]];
+struct VSOut {
+    float4 pos [[position]];
+    float2 uv;
+    float  framePhase;
 };
 
-vertex VertexOut prominence_vertex(
-    const device ProminenceParticle *particles [[buffer(0)]],
-    constant float4x4 &mvpMatrix [[buffer(1)]],
-    constant float    &lifetime  [[buffer(2)]],
-    uint id [[vertex_id]]) {
+struct Camera {
+    float4x4 viewProj;
+    float3 camRight;
+    float3 camUp;
+};
 
-    ProminenceParticle p = particles[id];
-    VertexOut out;
-    out.position = mvpMatrix * float4(p.position, 1.0);
-    out.life = p.life;
-    float age = 1.0 - p.life / lifetime;
-    out.pointSize = 1.0 + (1.0 - age) * 2.0;
-    return out;
+struct ProminenceParams {
+    float time;
+    float flipFps;
+    int   cols;
+    int   rows;
+    float intensity;
+    float hueShift;
+    float2 noiseUV;
+};
+
+vertex VSOut prom_vertex(VSIn in [[stage_in]],
+                         constant Camera &cam [[buffer(1)]],
+                         constant ProminenceParams &P [[buffer(2)]]) {
+    VSOut o;
+    float3 right = normalize(cam.camRight);
+    float3 up = normalize(cam.camUp);
+    float2 size = in.corner * in.scale;
+    float3 pos = in.worldPos + right * size.x + up * size.y;
+    o.pos = cam.viewProj * float4(pos, 1.0);
+    o.uv = in.corner * float2(1.0, -1.0) + 0.5;
+    o.framePhase = in.startPhase + (P.time * P.flipFps * in.fpsMul);
+    return o;
 }
 
-fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
-    float age = 1.0 - in.life / lifetime;
-    float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
+float3 hueShift(float3 c, float shift) {
+    return c; // placeholder
+}
+
+fragment float4 prom_fragment(VSOut in [[stage_in]],
+                              texture2d<float> flipbook [[texture(0)]],
+                              texture2d<float> noiseTex [[texture(1)]],
+                              sampler sLin [[sampler(0)]],
+                              constant ProminenceParams &P [[buffer(0)]]) {
+    int total = P.cols * P.rows;
+    float f = floor(fract(in.framePhase) * float(total));
+    int idx = int(f) % total;
+    int cx = idx % P.cols;
+    int cy = idx / P.cols;
+    float2 cellSize = float2(1.0 / float(P.cols), 1.0 / float(P.rows));
+    float2 base = float2(cx, cy) * cellSize;
+    float2 uv = base + in.uv * cellSize;
+    float4 s = flipbook.sample(sLin, uv);
+    float n = noiseTex.sample(sLin, uv * P.noiseUV + P.time * 0.2).r;
+    float intensity = P.intensity * (0.9 + 0.2 * n);
+    float3 col = hueShift(s.rgb * intensity, P.hueShift);
+    return float4(col, s.a * intensity);
 }
 


### PR DESCRIPTION
## Summary
- parse timing data and define ProminenceRenderer for solar limb sprites
- add billboard flipbook shader and integrate with MetalRenderer
- provide sample timing configuration for prominence spawns

## Testing
- `xcodebuild build` *(command not found: xcodebuild)*
- `xcodebuild test` *(command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba835fa08327b7d7447c43502db5