### PR TITLE
Render flipbook-based solar prominences

### DIFF
--- a/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
+++ b/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
@@ -1,16 +1,7 @@
-Prominence Flipbook Timing Guide
-
-Frames: 16
-Resolution per frame: 512x512
-Atlas layout: vertical strip (512 x 8192)
-Playback: 12-15 FPS
-Cycle length: ~1.19 seconds
-
-UV indexing (GLSL-like pseudocode):
------------------------------------
-int N = 16;
-float fps = 13.5;
-float frame = floor(mod(time * fps, float(N)));
-float vStep = 1.0 / float(N);
-vec2 uvAtlas = vec2(uv.x, uv.y / float(N) + frame * vStep);
-vec4 tex = texture(flipbookTex, uvAtlas);
+# frameCount cols rows fps baseIntensity variance seed
+16 1 16 13.5 1.0 0.25 1337
+# entries: angleDeg radiusMul lift scale fpsMul startPhase
+0   1.05 0.02 0.05 1.0 0.0
+45  1.07 0.03 0.07 1.1 0.3
+90  1.10 0.04 0.09 0.9 0.6
+135 1.08 0.05 0.08 1.2 0.2

--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominencesRenderer: ProminencesRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominencesRenderer = ProminencesRenderer(device: device, sunRadius: sunRenderer.radius)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -187,6 +189,12 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                               viewMatrix: viewMatrix,
                               projectionMatrix: projectionMatrix,
                               viewportSize: metalView.bounds.size)
+
+        prominencesRenderer.render(with: renderEncoder,
+                                   time: time,
+                                   viewMatrix: viewMatrix,
+                                   projectionMatrix: projectionMatrix,
+                                   modelMatrix: sunRenderer.modelMatrix)
 
         if let sunWorld = sunRenderer.worldPosition {
             coronaRenderer.render(with: renderEncoder,

--- a/OptiUniverse/Renderers/ProminencesRenderer.swift
+++ b/OptiUniverse/Renderers/ProminencesRenderer.swift
@@ -1,0 +1,199 @@
+import Foundation
+import MetalKit
+import simd
+
+struct ProminenceParams {
+    var time: Float = 0
+    var flipFps: Float = 16
+    var cols: Int32 = 1
+    var rows: Int32 = 1
+    var intensity: Float = 1
+    var hueShift: Float = 0
+    var noiseUV: SIMD2<Float> = SIMD2<Float>(1,1)
+}
+
+struct ProminenceVertex {
+    var worldPos: SIMD3<Float>
+    var corner: SIMD2<Float>
+    var scale: Float
+    var startPhase: Float
+    var fpsMul: Float
+}
+
+struct CameraData {
+    var viewProj: float4x4
+    var camRight: SIMD3<Float>
+    var camUp: SIMD3<Float>
+}
+
+final class ProminencesRenderer {
+    private let device: MTLDevice
+    private let pipelineState: MTLRenderPipelineState
+    private let samplerState: MTLSamplerState
+    private let flipbook: MTLTexture
+    private let noise: MTLTexture
+    private var vertexBuffer: MTLBuffer?
+    private var spriteCount: Int = 0
+    private var params = ProminenceParams()
+
+    init(device: MTLDevice, sunRadius: Float) {
+        self.device = device
+        self.pipelineState = ProminencesRenderer.makePipelineState(device: device)
+        self.samplerState = ProminencesRenderer.makeSamplerState(device: device)
+        self.flipbook = ProminencesRenderer.loadTexture(device: device, name: "prominence_flipbook")
+        self.noise = ProminencesRenderer.loadTexture(device: device, name: "corona_noise_512")
+        loadTiming(device: device, radius: sunRadius)
+    }
+
+    private func loadTiming(device: MTLDevice, radius: Float) {
+        guard let url = Bundle.main.url(forResource: "prominence_flipbook_timing", withExtension: "txt"),
+              let data = try? String(contentsOf: url) else {
+            return
+        }
+        var lines = data.split(whereSeparator: { $0.isNewline })
+        guard !lines.isEmpty else { return }
+        func parseFloats(_ line: Substring) -> [Float] {
+            line.split(whereSeparator: { $0 == " " || $0 == "\t" })
+                .compactMap { Float($0) }
+        }
+        // Header
+        var headerParsed = false
+        var entries: [ProminenceVertex] = []
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.first == "#" { continue }
+            let nums = parseFloats(Substring(trimmed))
+            if !headerParsed {
+                if nums.count >= 6 {
+                    params.cols = Int32(nums[1])
+                    params.rows = Int32(nums[2])
+                    params.flipFps = nums[3]
+                    params.intensity = nums[4]
+                }
+                headerParsed = true
+            } else {
+                if nums.count >= 6 {
+                    let angle = nums[0] * Float.pi / 180
+                    let radiusMul = nums[1]
+                    let lift = nums[2]
+                    let scale = nums[3]
+                    let fpsMul = nums[4]
+                    let startPhase = nums[5]
+                    let r = radius * radiusMul
+                    let center = SIMD3<Float>(cos(angle) * r, lift * radius, sin(angle) * r)
+                    let size = scale * radius
+                    let corners: [SIMD2<Float>] = [
+                        SIMD2<Float>(-0.5, -0.5),
+                        SIMD2<Float>( 0.5, -0.5),
+                        SIMD2<Float>(-0.5,  0.5),
+                        SIMD2<Float>( 0.5,  0.5)
+                    ]
+                    for c in corners {
+                        entries.append(ProminenceVertex(worldPos: center,
+                                                        corner: c,
+                                                        scale: size,
+                                                        startPhase: startPhase,
+                                                        fpsMul: fpsMul))
+                    }
+                }
+            }
+        }
+        spriteCount = entries.count / 4
+        let length = entries.count * MemoryLayout<ProminenceVertex>.stride
+        vertexBuffer = device.makeBuffer(bytes: entries, length: length, options: [])
+    }
+
+    func render(with renderEncoder: MTLRenderCommandEncoder,
+                time: Float,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4,
+                modelMatrix: float4x4) {
+        guard let vertexBuffer = vertexBuffer else { return }
+        var params = self.params
+        params.time = time
+        let invView = viewMatrix.inverse
+        var cam = CameraData(viewProj: projectionMatrix * viewMatrix,
+                             camRight: SIMD3<Float>(invView.columns.0.x, invView.columns.0.y, invView.columns.0.z),
+                             camUp: SIMD3<Float>(invView.columns.1.x, invView.columns.1.y, invView.columns.1.z))
+
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        renderEncoder.setVertexBytes(&cam, length: MemoryLayout<CameraData>.stride, index: 1)
+        renderEncoder.setVertexBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 2)
+        var model = modelMatrix
+        renderEncoder.setVertexBytes(&model, length: MemoryLayout<float4x4>.stride, index: 3)
+
+        renderEncoder.setFragmentTexture(flipbook, index: 0)
+        renderEncoder.setFragmentTexture(noise, index: 1)
+        renderEncoder.setFragmentSamplerState(samplerState, index: 0)
+        renderEncoder.setFragmentBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 0)
+
+        for i in 0..<spriteCount {
+            renderEncoder.drawPrimitives(type: .triangleStrip,
+                                         vertexStart: i * 4,
+                                         vertexCount: 4)
+        }
+    }
+
+    private static func makePipelineState(device: MTLDevice) -> MTLRenderPipelineState {
+        let library = device.makeDefaultLibrary()!
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.sampleCount = 4
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "prominence_vertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "prominence_fragment")
+        let blend = descriptor.colorAttachments[0]
+        blend?.isBlendingEnabled = true
+        blend?.rgbBlendOperation = .add
+        blend?.alphaBlendOperation = .add
+        blend?.sourceRGBBlendFactor = .one
+        blend?.destinationRGBBlendFactor = .one
+        blend?.sourceAlphaBlendFactor = .one
+        blend?.destinationAlphaBlendFactor = .one
+        descriptor.vertexDescriptor = makeVertexDescriptor()
+        return try! device.makeRenderPipelineState(descriptor: descriptor)
+    }
+
+    private static func makeVertexDescriptor() -> MTLVertexDescriptor {
+        let vd = MTLVertexDescriptor()
+        vd.attributes[0].format = .float3
+        vd.attributes[0].offset = 0
+        vd.attributes[0].bufferIndex = 0
+        vd.attributes[1].format = .float2
+        vd.attributes[1].offset = MemoryLayout<Float>.stride * 3
+        vd.attributes[1].bufferIndex = 0
+        vd.attributes[2].format = .float
+        vd.attributes[2].offset = MemoryLayout<Float>.stride * 5
+        vd.attributes[2].bufferIndex = 0
+        vd.attributes[3].format = .float
+        vd.attributes[3].offset = MemoryLayout<Float>.stride * 6
+        vd.attributes[3].bufferIndex = 0
+        vd.attributes[4].format = .float
+        vd.attributes[4].offset = MemoryLayout<Float>.stride * 7
+        vd.attributes[4].bufferIndex = 0
+        vd.layouts[0].stride = MemoryLayout<ProminenceVertex>.stride
+        return vd
+    }
+
+    private static func makeSamplerState(device: MTLDevice) -> MTLSamplerState {
+        let desc = MTLSamplerDescriptor()
+        desc.sAddressMode = .clampToEdge
+        desc.tAddressMode = .clampToEdge
+        desc.minFilter = .linear
+        desc.magFilter = .linear
+        desc.mipFilter = .linear
+        return device.makeSamplerState(descriptor: desc)!
+    }
+
+    private static func loadTexture(device: MTLDevice, name: String) -> MTLTexture {
+        let loader = MTKTextureLoader(device: device)
+        let options: [MTKTextureLoader.Option: Any] = [
+            .origin: MTKTextureLoader.Origin.topLeft.rawValue,
+            .generateMipmaps: true
+        ]
+        let url = Bundle.main.url(forResource: name, withExtension: "png")!
+        return try! loader.newTexture(URL: url, options: options)
+    }
+}
+

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -1,38 +1,69 @@
 #include <metal_stdlib>
 using namespace metal;
 
-struct ProminenceParticle {
-    float3 position;
-    float  angle;
-    float  life;
+struct VSIn {
+    float3 worldPos [[attribute(0)]];
+    float2 corner [[attribute(1)]];
+    float  scale [[attribute(2)]];
+    float  startPhase [[attribute(3)]];
+    float  fpsMul [[attribute(4)]];
 };
 
-struct VertexOut {
-    float4 position [[position]];
-    float  life;
-    float  pointSize [[point_size]];
+struct VSOut {
+    float4 pos [[position]];
+    float2 uv;
+    float  framePhase;
 };
 
-vertex VertexOut prominence_vertex(
-    const device ProminenceParticle *particles [[buffer(0)]],
-    constant float4x4 &mvpMatrix [[buffer(1)]],
-    constant float    &lifetime  [[buffer(2)]],
-    uint id [[vertex_id]]) {
+struct Camera {
+    float4x4 viewProj;
+    float3   camRight;
+    float3   camUp;
+};
 
-    ProminenceParticle p = particles[id];
-    VertexOut out;
-    out.position = mvpMatrix * float4(p.position, 1.0);
-    out.life = p.life;
-    float age = 1.0 - p.life / lifetime;
-    out.pointSize = 1.0 + (1.0 - age) * 2.0;
-    return out;
+struct ProminenceParams {
+    float  time;
+    float  flipFps;
+    int    cols;
+    int    rows;
+    float  intensity;
+    float  hueShift;
+    float2 noiseUV;
+};
+
+vertex VSOut prominence_vertex(VSIn in [[stage_in]],
+                              constant Camera& cam [[buffer(1)]],
+                              constant ProminenceParams& P [[buffer(2)]],
+                              constant float4x4& model [[buffer(3)]]) {
+    VSOut o;
+    float4 center = model * float4(in.worldPos, 1.0);
+    float3 right = normalize(cam.camRight);
+    float3 up = normalize(cam.camUp);
+    float2 size = in.corner * in.scale;
+    float3 pos = center.xyz + right * size.x + up * size.y;
+    o.pos = cam.viewProj * float4(pos, 1.0);
+    o.uv = in.corner * float2(1.0, -1.0) + 0.5;
+    o.framePhase = in.startPhase + (P.time * P.flipFps * in.fpsMul);
+    return o;
 }
 
-fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
-    float age = 1.0 - in.life / lifetime;
-    float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
+fragment float4 prominence_fragment(VSOut in [[stage_in]],
+                                    texture2d<float> flipbook [[texture(0)]],
+                                    texture2d<float> noiseTex [[texture(1)]],
+                                    sampler sLin [[sampler(0)]],
+                                    constant ProminenceParams& P [[buffer(0)]]) {
+    int total = P.cols * P.rows;
+    float f = floor(fract(in.framePhase) * float(total));
+    int idx = int(f) % total;
+    int cx = idx % P.cols;
+    int cy = idx / P.cols;
+    float2 cellSize = 1.0 / float2(P.cols, P.rows);
+    float2 base = float2(cx, cy) * cellSize;
+    float2 uv = base + in.uv * cellSize;
+    float4 s = flipbook.sample(sLin, uv);
+    float n = noiseTex.sample(sLin, in.uv * P.noiseUV).r;
+    float intensity = P.intensity * (0.9 + 0.2 * n);
+    float3 col = s.rgb * intensity;
+    return float4(col, s.a * intensity);
 }
 


### PR DESCRIPTION
## Summary
- render animated solar prominences using flipbook billboards
- parse timing data to place and animate sprites around sun
- integrate prominence renderer into main Metal pipeline

## Testing
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba835fa08327b7d7447c43502db5