### PR TITLE
Add flipbook-based solar prominences

### DIFF
--- a/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
+++ b/OptiUniverse/Assets/Flipbooks/prominence_flipbook_timing.txt
@@ -1,16 +1,8 @@
-Prominence Flipbook Timing Guide
-
-Frames: 16
-Resolution per frame: 512x512
-Atlas layout: vertical strip (512 x 8192)
-Playback: 12-15 FPS
-Cycle length: ~1.19 seconds
-
-UV indexing (GLSL-like pseudocode):
------------------------------------
-int N = 16;
-float fps = 13.5;
-float frame = floor(mod(time * fps, float(N)));
-float vStep = 1.0 / float(N);
-vec2 uvAtlas = vec2(uv.x, uv.y / float(N) + frame * vStep);
-vec4 tex = texture(flipbookTex, uvAtlas);
+# frameCount cols rows fps baseIntensity variance seed
+16 1 16 13.5 1.0 0.25 1337
+# entries: angleDeg radiusMul lift scale fpsMul startPhase
+0   1.03 0.02 0.06 1.0 0.0
+45  1.05 0.03 0.08 0.9 0.3
+90  1.08 0.04 0.10 1.1 0.6
+135 1.06 0.025 0.07 1.0 0.2
+180 1.04 0.03 0.09 0.8 0.5

--- a/OptiUniverse/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Renderers/MetalRenderer.swift
@@ -31,6 +31,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private let planetsRenderer: PlanetsRenderer
     private let sunRenderer: SunRenderer
     private let coronaRenderer: CoronaRenderer
+    private let prominenceRenderer: ProminenceRenderer
     private let metalView: MTKView
 
     weak var labelDelegate: PlanetLabelDelegate?
@@ -89,6 +90,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         planetsRenderer = PlanetsRenderer(device: device)
         sunRenderer = SunRenderer(device: device)
         coronaRenderer = CoronaRenderer(device: device, sunRadius: sunRenderer.radius)
+        prominenceRenderer = ProminenceRenderer(device: device, sunRadius: sunRenderer.radius)
         
         viewMatrix = matrix_identity_float4x4
         projectionMatrix = matrix_identity_float4x4
@@ -187,6 +189,11 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                               viewMatrix: viewMatrix,
                               projectionMatrix: projectionMatrix,
                               viewportSize: metalView.bounds.size)
+
+        prominenceRenderer.render(with: renderEncoder,
+                                 time: time,
+                                 viewMatrix: viewMatrix,
+                                 projectionMatrix: projectionMatrix)
 
         if let sunWorld = sunRenderer.worldPosition {
             coronaRenderer.render(with: renderEncoder,

--- a/OptiUniverse/Renderers/ProminenceRenderer.swift
+++ b/OptiUniverse/Renderers/ProminenceRenderer.swift
@@ -1,0 +1,199 @@
+import Foundation
+import MetalKit
+import simd
+
+struct ProminenceParams {
+    var time: Float
+    var flipFps: Float
+    var cols: Int32
+    var rows: Int32
+    var intensity: Float
+    var hueShift: Float
+    var noiseUV: SIMD2<Float>
+}
+
+final class ProminenceRenderer {
+    private struct Vertex {
+        var worldPos: SIMD3<Float>
+        var corner: SIMD2<Float>
+        var scale: Float
+        var startPhase: Float
+        var fpsMul: Float
+        var padding: SIMD3<Float> = .zero
+    }
+
+    private struct Camera {
+        var viewProj: float4x4
+        var camRight: SIMD3<Float>
+        var pad0: Float = 0
+        var camUp: SIMD3<Float>
+        var pad1: Float = 0
+    }
+
+    private struct TimingEntry {
+        var angleDeg: Float
+        var radiusMul: Float
+        var lift: Float
+        var scale: Float
+        var fpsMul: Float
+        var startPhase: Float
+    }
+
+    private let device: MTLDevice
+    private let pipelineState: MTLRenderPipelineState
+    private let depthState: MTLDepthStencilState
+    private let sampler: MTLSamplerState
+    private let flipbook: MTLTexture
+    private let noise: MTLTexture
+    private let vertexBuffer: MTLBuffer
+    private let vertexCount: Int
+    private var params: ProminenceParams
+
+    init(device: MTLDevice, sunRadius: Float) {
+        self.device = device
+        self.pipelineState = ProminenceRenderer.makePipelineState(device: device)
+        self.depthState = ProminenceRenderer.makeDepthState(device: device)
+        self.sampler = ProminenceRenderer.makeSampler(device: device)
+        self.flipbook = ProminenceRenderer.loadTexture(device: device, name: "prominence_flipbook")
+        self.noise = ProminenceRenderer.loadTexture(device: device, name: "corona_noise_512")
+        let timing = ProminenceRenderer.loadTiming(sunRadius: sunRadius)
+        self.vertexBuffer = device.makeBuffer(bytes: timing.vertices,
+                                             length: MemoryLayout<Vertex>.stride * timing.vertices.count,
+                                             options: [])!
+        self.vertexCount = timing.vertices.count
+        self.params = ProminenceParams(time: 0,
+                                       flipFps: timing.fps,
+                                       cols: Int32(timing.cols),
+                                       rows: Int32(timing.rows),
+                                       intensity: timing.baseIntensity,
+                                       hueShift: 0,
+                                       noiseUV: SIMD2<Float>(4, 4))
+    }
+
+    func render(with renderEncoder: MTLRenderCommandEncoder,
+                time: Float,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4) {
+        var params = self.params
+        params.time = time
+        let invView = viewMatrix.inverse
+        var cam = Camera(viewProj: projectionMatrix * viewMatrix,
+                         camRight: SIMD3<Float>(invView.columns.0.x,
+                                                invView.columns.0.y,
+                                                invView.columns.0.z),
+                         camUp: SIMD3<Float>(invView.columns.1.x,
+                                             invView.columns.1.y,
+                                             invView.columns.1.z))
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setDepthStencilState(depthState)
+        renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        renderEncoder.setVertexBytes(&cam, length: MemoryLayout<Camera>.stride, index: 1)
+        renderEncoder.setVertexBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 2)
+        renderEncoder.setFragmentBytes(&params, length: MemoryLayout<ProminenceParams>.stride, index: 1)
+        renderEncoder.setFragmentTexture(flipbook, index: 0)
+        renderEncoder.setFragmentTexture(noise, index: 1)
+        renderEncoder.setFragmentSamplerState(sampler, index: 0)
+        renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: vertexCount)
+    }
+
+    private static func makePipelineState(device: MTLDevice) -> MTLRenderPipelineState {
+        let library = device.makeDefaultLibrary()!
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.colorAttachments[0].pixelFormat = .rgba16Float
+        descriptor.depthAttachmentPixelFormat = .depth32Float
+        descriptor.vertexFunction = library.makeFunction(name: "promVS")
+        descriptor.fragmentFunction = library.makeFunction(name: "promFS")
+        let blend = descriptor.colorAttachments[0]!
+        blend.isBlendingEnabled = true
+        blend.rgbBlendOperation = .add
+        blend.alphaBlendOperation = .add
+        blend.sourceRGBBlendFactor = .one
+        blend.destinationRGBBlendFactor = .one
+        blend.sourceAlphaBlendFactor = .one
+        blend.destinationAlphaBlendFactor = .one
+        return try! device.makeRenderPipelineState(descriptor: descriptor)
+    }
+
+    private static func makeDepthState(device: MTLDevice) -> MTLDepthStencilState {
+        let desc = MTLDepthStencilDescriptor()
+        desc.depthCompareFunction = .lessEqual
+        desc.isDepthWriteEnabled = false
+        return device.makeDepthStencilState(descriptor: desc)!
+    }
+
+    private static func makeSampler(device: MTLDevice) -> MTLSamplerState {
+        let desc = MTLSamplerDescriptor()
+        desc.sAddressMode = .clampToEdge
+        desc.tAddressMode = .clampToEdge
+        desc.minFilter = .linear
+        desc.magFilter = .linear
+        return device.makeSamplerState(descriptor: desc)!
+    }
+
+    private static func loadTiming(sunRadius: Float) -> (vertices: [Vertex], cols: Int, rows: Int, fps: Float, baseIntensity: Float) {
+        guard let url = Bundle.main.url(forResource: "prominence_flipbook_timing", withExtension: "txt") else {
+            return ([], 1, 1, 12, 1)
+        }
+        let text = (try? String(contentsOf: url)) ?? ""
+        var headerParsed = false
+        var cols = 1
+        var rows = 1
+        var fps: Float = 12
+        var baseIntensity: Float = 1
+        var entries: [TimingEntry] = []
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            let parts = trimmed.split { $0 == " " || $0 == "\t" }
+            if !headerParsed {
+                if parts.count >= 7 {
+                    cols = Int(parts[1]) ?? 1
+                    rows = Int(parts[2]) ?? 1
+                    fps = Float(parts[3]) ?? 12
+                    baseIntensity = Float(parts[4]) ?? 1
+                }
+                headerParsed = true
+            } else {
+                if parts.count >= 6 {
+                    let e = TimingEntry(angleDeg: Float(parts[0]) ?? 0,
+                                         radiusMul: Float(parts[1]) ?? 1,
+                                         lift: Float(parts[2]) ?? 0,
+                                         scale: Float(parts[3]) ?? 0.05,
+                                         fpsMul: Float(parts[4]) ?? 1,
+                                         startPhase: Float(parts[5]) ?? 0)
+                    entries.append(e)
+                }
+            }
+        }
+        var vertices: [Vertex] = []
+        for e in entries {
+            let angle = e.angleDeg * (.pi / 180)
+            let dir = SIMD3<Float>(cos(angle), sin(angle), 0)
+            let base = sunRadius * e.radiusMul
+            let pos = dir * (base + sunRadius * e.lift)
+            let scale = sunRadius * e.scale
+            let corners: [SIMD2<Float>] = [
+                SIMD2<Float>(-0.5, -0.5),
+                SIMD2<Float>( 0.5, -0.5),
+                SIMD2<Float>(-0.5,  0.5),
+                SIMD2<Float>(-0.5,  0.5),
+                SIMD2<Float>( 0.5, -0.5),
+                SIMD2<Float>( 0.5,  0.5)
+            ]
+            for c in corners {
+                vertices.append(Vertex(worldPos: pos,
+                                       corner: c,
+                                       scale: scale,
+                                       startPhase: e.startPhase,
+                                       fpsMul: e.fpsMul))
+            }
+        }
+        return (vertices, cols, rows, fps, baseIntensity)
+    }
+
+    private static func loadTexture(device: MTLDevice, name: String) -> MTLTexture {
+        let loader = MTKTextureLoader(device: device)
+        let url = Bundle.main.url(forResource: name, withExtension: "png")!
+        return try! loader.newTexture(URL: url, options: [.origin: MTKTextureLoader.Origin.topLeft.rawValue])
+    }
+}

--- a/OptiUniverse/Shaders/Prominences.render.metal
+++ b/OptiUniverse/Shaders/Prominences.render.metal
@@ -1,38 +1,75 @@
 #include <metal_stdlib>
 using namespace metal;
 
-struct ProminenceParticle {
-    float3 position;
-    float  angle;
-    float  life;
+struct VSIn {
+    float3 worldPos;
+    float2 corner;
+    float  scale;
+    float  startPhase;
+    float  fpsMul;
+    float3 pad;
 };
 
-struct VertexOut {
-    float4 position [[position]];
-    float  life;
-    float  pointSize [[point_size]];
+struct VSOut {
+    float4 pos [[position]];
+    float2 uv;
+    float  framePhase;
+    float  vScale;
 };
 
-vertex VertexOut prominence_vertex(
-    const device ProminenceParticle *particles [[buffer(0)]],
-    constant float4x4 &mvpMatrix [[buffer(1)]],
-    constant float    &lifetime  [[buffer(2)]],
-    uint id [[vertex_id]]) {
+struct Camera {
+    float4x4 viewProj;
+    float3   camRight;
+    float    pad0;
+    float3   camUp;
+    float    pad1;
+};
 
-    ProminenceParticle p = particles[id];
-    VertexOut out;
-    out.position = mvpMatrix * float4(p.position, 1.0);
-    out.life = p.life;
-    float age = 1.0 - p.life / lifetime;
-    out.pointSize = 1.0 + (1.0 - age) * 2.0;
-    return out;
+struct ProminenceParams {
+    float time;
+    float flipFps;
+    int   cols;
+    int   rows;
+    float intensity;
+    float hueShift;
+    float2 noiseUV;
+};
+
+vertex VSOut promVS(uint vid [[vertex_id]],
+                    const device VSIn *in [[buffer(0)]],
+                    constant Camera &cam [[buffer(1)]],
+                    constant ProminenceParams &P [[buffer(2)]]) {
+    VSIn v = in[vid];
+    VSOut o;
+    float3 right = normalize(cam.camRight);
+    float3 up    = normalize(cam.camUp);
+    float2 size = v.corner * v.scale;
+    float3 pos = v.worldPos + right * size.x + up * size.y;
+    o.pos = cam.viewProj * float4(pos, 1.0);
+    o.uv = v.corner * float2(1.0, -1.0) + 0.5;
+    float total = float(P.cols * P.rows);
+    o.framePhase = v.startPhase + (P.time * P.flipFps * v.fpsMul) / total;
+    o.vScale = v.scale;
+    return o;
 }
 
-fragment float4 prominence_fragment(VertexOut in [[stage_in]],
-                                    constant float &lifetime [[buffer(0)]]) {
-    float age = 1.0 - in.life / lifetime;
-    float alpha = (1.0 - age) * (1.0 - age);
-    float3 color = float3(1.0, 0.5, 0.2) * alpha;
-    return float4(color, alpha); // Additive blending expected
-}
+fragment float4 promFS(VSOut in [[stage_in]],
+                       texture2d<float> flipbook [[texture(0)]],
+                       texture2d<float> noiseTex [[texture(1)]],
+                       sampler sLin [[sampler(0)]],
+                       constant ProminenceParams &P [[buffer(1)]]) {
+    int total = P.cols * P.rows;
+    float f = floor(fract(in.framePhase) * float(total));
+    int idx = int(f) % total;
+    int cx = idx % P.cols;
+    int cy = idx / P.cols;
+    float2 cellSize = 1.0 / float2(P.cols, P.rows);
+    float2 base = float2(cx, cy) * cellSize;
+    float2 uv = base + in.uv * cellSize;
 
+    float4 s = flipbook.sample(sLin, uv);
+    float n = noiseTex.sample(sLin, uv * P.noiseUV + P.time * 0.2).r;
+    float intensity = P.intensity * (0.9 + 0.2 * n);
+    float3 col = s.rgb * intensity;
+    return float4(col, s.a * intensity);
+}


### PR DESCRIPTION
## Summary
- Implement flipbook-based solar prominence shader and renderer
- Parse timing file to spawn billboard sprites and animate frames
- Hook prominence renderer into main Metal renderer

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `xcodebuild build` *(fails: command not found)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba835fa08327b7d7447c43502db5