### PR TITLE
Add JSON-backed destination cards

### DIFF
--- a/OptiUniverse/Resources/DestinationObjects.json
+++ b/OptiUniverse/Resources/DestinationObjects.json
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "2A362A51-31E5-4609-8B0D-CE2FBC314F15",
+        "title": "Mars mountains",
+        "subtitle": "Dusty Red Planet",
+        "imageName": "Mars_Perseverance_ZR0_0812_0739017260_428EBY_N0391170ZCAM03671_0340LMJ"
+    },
+    {
+        "id": "2F2B045C-4C7C-4797-A423-BAC3665F67AF",
+        "title": "Neptune Scooter",
+        "subtitle": "Windy Blue Planet",
+        "imageName": "PIA01142~orig"
+    },
+    {
+        "id": "65759265-BD0F-43F8-BE5C-BD877D0EE4F6",
+        "title": "Lunar landscape",
+        "subtitle": "Nearest destination to Earth",
+        "imageName": "s2-1280"
+    },
+    {
+        "id": "26953D18-B242-43A0-8CC8-CF861E4AD68D",
+        "title": "Lunar landscape",
+        "subtitle": "Nearest destination to Earth",
+        "imageName": "s2-1280"
+    }
+]

--- a/OptiUniverse/UIComponents/DestinationListView/DestinationListViewModel.swift
+++ b/OptiUniverse/UIComponents/DestinationListView/DestinationListViewModel.swift
@@ -13,26 +13,18 @@ final class DestinationListViewModel {
     var cards: [DestinationCardModel] = []
     
     func loadCards() {
-        // TODO: Implement json, same as FeaturedObjects
-        // TODO: Fix Codex warning
-//        loadCards() is invoked unconditionally in .onAppear, but DestinationListViewModel.loadCards() creates every DestinationCardModel with a fresh UUID (id: .init()). When this screen appears again (for example after navigating away and back), all item identities change and ForEach treats the list as brand-new content, which can reset scroll position and cause visible churn. Guard this call (or make IDs stable) so item identity persists across appearances.
-        cards = [
-            DestinationCardModel(id: .init(),
-                                 title: "Mars mountains",
-                                 subtitle: "Dusty Red Planet",
-                                 imageResource: .marsPerseveranceZR008120739017260428EBYN0391170ZCAM036710340LMJ),
-            DestinationCardModel(id: .init(),
-                                 title: "Neptune Scooter",
-                                 subtitle: "Windy Blue Planet",
-                                 imageResource: .pia01142Orig),
-            DestinationCardModel(id: .init(),
-                                 title: "Lunar landscape",
-                                 subtitle: "Nearest destination to Earth",
-                                 imageResource: .s21280),
-            DestinationCardModel(id: .init(),
-                                 title: "Lunar landscape",
-                                 subtitle: "Nearest destination to Earth",
-                                 imageResource: .s21280)
-        ]
+        guard cards.isEmpty else {
+            return
+        }
+        
+        let destinationObjects: [DestinationObject] = Bundle.main.loadConfig(filename: "DestinationObjects")
+        cards = destinationObjects.map {
+            DestinationCardModel(
+                id: $0.id,
+                title: $0.title,
+                subtitle: $0.subtitle,
+                imageResource: ImageResource(name: $0.imageName, bundle: .main)
+            )
+        }
     }
 }

--- a/OptiUniverse/UIComponents/DestinationListView/DestinationObject.swift
+++ b/OptiUniverse/UIComponents/DestinationListView/DestinationObject.swift
@@ -1,0 +1,15 @@
+//
+//  DestinationObject.swift
+//  OptiUniverse
+//
+//  Created by Codex on 19.04.2026.
+//
+
+import Foundation
+
+struct DestinationObject: Decodable {
+    let id: UUID
+    let title: String
+    let subtitle: String
+    let imageName: String
+}


### PR DESCRIPTION
## Summary
- Replace the hardcoded destination card list with JSON-backed decoding
- Add a `DestinationObject` decodable model to mirror the `FeaturedObjects` pattern
- Preserve stable card identity by loading once and using UUIDs from JSON

## Testing
- Not run (not requested)