### PR TITLE
Fix free object rotation without camera lock

### DIFF
--- a/OptiUniverse/Features/Metal/CameraController.swift
+++ b/OptiUniverse/Features/Metal/CameraController.swift
@@ -50,7 +50,6 @@ final class CameraController: NSObject {
         if yawVelocity != 0 || pitchVelocity != 0 || zoomVelocity != 0 {
             renderer.cameraYaw += yawVelocity * delta
             renderer.cameraPitch += pitchVelocity * delta
-            renderer.cameraPitch = max(0.1, min(renderer.cameraPitch, .pi/2 - 0.01))
             renderer.cameraDistance = max(minDistance,
                                           min(renderer.cameraDistance + zoomVelocity * delta,
                                               maxDistance))
@@ -75,7 +74,6 @@ final class CameraController: NSObject {
         let translation = gesture.translation(in: gesture.view)
         renderer.cameraYaw -= Float(translation.x) * orbitSpeed
         renderer.cameraPitch -= Float(translation.y) * orbitSpeed
-        renderer.cameraPitch = max(0.1, min(renderer.cameraPitch, .pi/2 - 0.01))
         gesture.setTranslation(.zero, in: gesture.view)
         renderer.updateCamera()
 

--- a/OptiUniverse/Features/Metal/Extensions/MatrixExtensions.swift
+++ b/OptiUniverse/Features/Metal/Extensions/MatrixExtensions.swift
@@ -56,13 +56,23 @@ extension float4x4 {
     static func lookAt(eye: SIMD3<Float>,
                        target: SIMD3<Float>,
                        up: SIMD3<Float>) -> float4x4 {
+        let epsilon: Float = 0.000001
         
         // 1. Calculate forward vector (z-axis)
-//        let z = normalize(eye - target)  // Points backward (toward camera)
-        let z = normalize(target - eye) // Working, deepseek was wrong?
+        let forward = target - eye
+        guard length_squared(forward) > epsilon else {
+            return matrix_identity_float4x4
+        }
+        let z = normalize(forward)
         
         // 2. Calculate right vector (x-axis)
-        let x = normalize(cross(up, z)) // Perpendicular to up and z
+        var resolvedUp = length_squared(up) > epsilon ? normalize(up) : SIMD3<Float>(0, 1, 0)
+        var right = cross(resolvedUp, z)
+        if length_squared(right) <= epsilon {
+            resolvedUp = abs(z.y) < 0.999 ? SIMD3<Float>(0, 1, 0) : SIMD3<Float>(0, 0, 1)
+            right = cross(resolvedUp, z)
+        }
+        let x = normalize(right) // Perpendicular to up and z
         
         // 3. Recalculate true up vector (y-axis)
         let y = cross(z, x)             // Guaranteed perpendicular

--- a/OptiUniverse/Features/Metal/Extensions/MatrixExtensions.swift
+++ b/OptiUniverse/Features/Metal/Extensions/MatrixExtensions.swift
@@ -57,18 +57,19 @@ extension float4x4 {
                        target: SIMD3<Float>,
                        up: SIMD3<Float>) -> float4x4 {
         let epsilon: Float = 0.000001
+        let epsilonSquared = epsilon * epsilon
         
         // 1. Calculate forward vector (z-axis)
         let forward = target - eye
-        guard length_squared(forward) > epsilon else {
+        guard length_squared(forward) > epsilonSquared else {
             return matrix_identity_float4x4
         }
         let z = normalize(forward)
         
         // 2. Calculate right vector (x-axis)
-        var resolvedUp = length_squared(up) > epsilon ? normalize(up) : SIMD3<Float>(0, 1, 0)
+        var resolvedUp = length_squared(up) > epsilonSquared ? normalize(up) : SIMD3<Float>(0, 1, 0)
         var right = cross(resolvedUp, z)
-        if length_squared(right) <= epsilon {
+        if length_squared(right) <= epsilonSquared {
             resolvedUp = abs(z.y) < 0.999 ? SIMD3<Float>(0, 1, 0) : SIMD3<Float>(0, 0, 1)
             right = cross(resolvedUp, z)
         }

--- a/OptiUniverse/Features/Metal/Renderers/MetalRenderer.swift
+++ b/OptiUniverse/Features/Metal/Renderers/MetalRenderer.swift
@@ -72,6 +72,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     var cameraPitch: Float = 0 // .pi/4  // Vertical tilt (45° default)
     var cameraTarget = SIMD3<Float>(0, 0, 0)
     private(set) var cameraPosition = SIMD3<Float>(0, 0, 0)
+    private(set) var cameraUp = SIMD3<Float>(0, 1, 0)
     private var followingPlanetName: String? = "Sun"
 
     // Camera animation state
@@ -220,7 +221,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         let renderViewMatrix = float4x4.lookAt(
             eye: renderCameraPosition,
             target: .zero,
-            up: SIMD3<Float>(0, 1, 0)
+            up: cameraUp
         )
 
         // Render the remaining planets.
@@ -337,6 +338,8 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     }
     
     func updateCamera() {
+        normalizeCameraAngles()
+
         // 1. Calculate orbit position
         let x = cameraDistance * sin(cameraYaw) * cos(cameraPitch)
         let y = cameraDistance * sin(cameraPitch)
@@ -344,14 +347,21 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         
         let cameraPosition = SIMD3<Float>(x, y, z) + cameraTarget
         self.cameraPosition = cameraPosition
+        cameraUp = cos(cameraPitch) >= 0 ? SIMD3<Float>(0, 1, 0) : SIMD3<Float>(0, -1, 0)
         
         // 2. Update matrices
         viewMatrix = float4x4.lookAt(
             eye: cameraPosition,
             target: cameraTarget,
-            up: SIMD3<Float>(0, 1, 0)
+            up: cameraUp
         )
         updateProjectionMatrix()
+    }
+
+    private func normalizeCameraAngles() {
+        let fullTurn = Float.pi * 2
+        cameraYaw = cameraYaw.remainder(dividingBy: fullTurn)
+        cameraPitch = cameraPitch.remainder(dividingBy: fullTurn)
     }
 
     private func distanceToFitPlanet(radius: Float) -> Float {


### PR DESCRIPTION
## Summary
- Remove the pitch clamp that trapped vertical drag inside a narrow orbit band
- Harden `lookAt` so the camera matrix stays valid when crossing the poles
- Track camera up-vector state so orbiting through top/bottom remains smooth

## Testing
- Built the app successfully on the available iPhone 17 Pro simulator runtime
- Ran the XCTest suite successfully on the same simulator runtime

Resolves #144 