### PR TITLE
Refine the planet cartoon shader to match the reference style

### DIFF
--- a/DebugPanelParameters.md
+++ b/DebugPanelParameters.md
@@ -7,3 +7,4 @@
 | Corona Mode | off, simple, detailed | Rendering technique for corona. |
 | Particle Count | 0–5000 | Number of emitted particles. |
 | Exposure | 0.1–5.0 | Multiplier applied to final color. |
+| Cartoon Shader Intensity | 0.0–1.0 | Blends from current lighting to cel-shaded cartoon rendering. |

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
@@ -47,7 +47,8 @@ extension MetalRenderer {
                                                       projectionMatrix: projectionMatrix,
                                                       cameraPosition: cameraOffset,
                                                       sceneOrigin: renderOrigin,
-                                                      viewportSize: metalView.bounds.size)
+                                                      viewportSize: metalView.bounds.size,
+                                                      cartoonShaderIntensity: min(max(cartoonShaderIntensity, 0), 1))
         // Render the remaining planets.
         planetsRenderer.renderPlanets(configuration: configuration)
         renderEncoder.endEncoding()

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -70,6 +70,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                     softFocusRadius: 1.9,
                                     hazeStrength: 0.3,
                                     saturationBoost: 1.08)
+    var cartoonShaderIntensity: Float = 0.75
 
     // Orbital Camera
     // Camera state

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
@@ -16,4 +16,5 @@ struct PlanetRenderConfiguration {
     let cameraPosition: SIMD3<Float>
     let sceneOrigin: SIMD3<Float>
     let viewportSize: CGSize
+    let cartoonShaderIntensity: Float
 }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer.swift
@@ -24,6 +24,7 @@ final class PlanetsRenderer {
     private struct FragmentUniforms {
         var cameraPosition: SIMD3<Float>
         var lightPosition: SIMD3<Float>
+        var cartoonShaderIntensity: Float
     }
 
     private static let colorPixelFormat: MTLPixelFormat = .rgba16Float
@@ -231,7 +232,8 @@ final class PlanetsRenderer {
         renderEncoder.setFragmentSamplerState(samplerState, index: 0)
         var fragmentUniforms = FragmentUniforms(
             cameraPosition: configuration.cameraPosition,
-            lightPosition: -configuration.sceneOrigin
+            lightPosition: -configuration.sceneOrigin,
+            cartoonShaderIntensity: min(max(configuration.cartoonShaderIntensity, 0), 1)
         )
         renderEncoder.setFragmentBytes(&fragmentUniforms,
                                        length: MemoryLayout<FragmentUniforms>.stride,

--- a/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
+++ b/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
@@ -61,6 +61,7 @@ struct MaterialUniforms {
 struct FragmentUniforms {
     float3 cameraPosition;
     float3 lightPosition;
+    float cartoonShaderIntensity;
 };
 
 float distributionGGX(float3 normal, float3 halfVector, float roughness) {
@@ -87,6 +88,81 @@ float geometrySmith(float3 normal, float3 viewDir, float3 lightDir, float roughn
 
 float3 fresnelSchlick(float cosTheta, float3 f0) {
     return f0 + (1.0 - f0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+float toonLightBand(float lightAmount) {
+    float light = saturate(lightAmount);
+    if (light < 0.18) {
+        return 0.18;
+    }
+    if (light < 0.45) {
+        return 0.42;
+    }
+    if (light < 0.74) {
+        return 0.72;
+    }
+    return 1.0;
+}
+
+float3 adjustSaturation(float3 color, float saturation) {
+    float luminance = dot(color, float3(0.299, 0.587, 0.114));
+    return mix(float3(luminance), color, saturation);
+}
+
+float luminance(float3 color) {
+    return dot(color, float3(0.299, 0.587, 0.114));
+}
+
+float3 posterizeColor(float3 color, float levels) {
+    return floor(color * levels + 0.5) / levels;
+}
+
+float textureInkLine(texture2d<float> baseTexture,
+                     sampler textureSampler,
+                     float2 uv) {
+    float2 texelSize = 1.0 / float2(max(float(baseTexture.get_width()), 1.0),
+                                    max(float(baseTexture.get_height()), 1.0));
+    texelSize *= 1.35;
+
+    float left = luminance(baseTexture.sample(textureSampler, uv - float2(texelSize.x, 0.0)).rgb);
+    float right = luminance(baseTexture.sample(textureSampler, uv + float2(texelSize.x, 0.0)).rgb);
+    float up = luminance(baseTexture.sample(textureSampler, uv + float2(0.0, texelSize.y)).rgb);
+    float down = luminance(baseTexture.sample(textureSampler, uv - float2(0.0, texelSize.y)).rgb);
+    float diagA = luminance(baseTexture.sample(textureSampler, uv + texelSize).rgb);
+    float diagB = luminance(baseTexture.sample(textureSampler, uv - texelSize).rgb);
+    float diagC = luminance(baseTexture.sample(textureSampler, uv + float2(texelSize.x, -texelSize.y)).rgb);
+    float diagD = luminance(baseTexture.sample(textureSampler, uv + float2(-texelSize.x, texelSize.y)).rgb);
+
+    float edge = max(max(abs(left - right), abs(up - down)),
+                     max(abs(diagA - diagB), abs(diagC - diagD)));
+    return smoothstep(0.025, 0.115, edge);
+}
+
+float3 cartoonShade(float3 litColor,
+                    float3 albedo,
+                    float3 emissive,
+                    float3 normal,
+                    float3 viewDir,
+                    float nDotL,
+                    float ambientOcclusion,
+                    float textureLine,
+                    float intensity) {
+    float bandedLight = toonLightBand(nDotL);
+    float3 saturatedAlbedo = adjustSaturation(albedo, mix(1.0, 1.18, intensity));
+    float3 drawnAlbedo = posterizeColor(saturatedAlbedo, mix(8.0, 5.0, intensity));
+    float lightingRamp = mix(0.78, 1.08, bandedLight);
+    float3 toonColor = drawnAlbedo * lightingRamp * max(ambientOcclusion, 0.58);
+    toonColor += emissive;
+
+    float textureInk = textureLine * mix(0.0, 0.48, intensity);
+    toonColor = mix(toonColor, toonColor * 0.42, textureInk);
+
+    float silhouette = smoothstep(0.34, 0.64, 1.0 - saturate(abs(dot(normal, viewDir))));
+    float3 inkColor = float3(0.0);
+    toonColor = mix(toonColor, inkColor, silhouette * mix(0.0, 0.92, intensity));
+    toonColor = max((toonColor - 0.03) * mix(1.0, 1.18, intensity) + 0.03, 0.0);
+
+    return mix(litColor, toonColor, intensity);
 }
 
 vertex VertexOut vertex_main(
@@ -144,6 +220,10 @@ fragment float4 fragment_main(VertexOut in [[stage_in]],
         float cloudCoverage = max(max(colorSample.r, colorSample.g), colorSample.b);
         alpha *= smoothstep(0.08, 0.72, cloudCoverage);
         albedo = float3(1.0);
+    }
+    float textureLine = 0.0;
+    if (planetTexture.get_width() > 2 && planetTexture.get_height() > 2) {
+        textureLine = textureInkLine(planetTexture, textureSampler, uv);
     }
 
     float3 normal = normalize(in.normal);
@@ -217,6 +297,18 @@ fragment float4 fragment_main(VertexOut in [[stage_in]],
     }
     if (materialUniforms.whiteAlbedo > 0.5) {
         litColor = albedo * (0.05 + cloudLight * 1.35);
+    }
+    float cartoonIntensity = saturate(fragmentUniforms.cartoonShaderIntensity);
+    if (cartoonIntensity > 0.0) {
+        litColor = cartoonShade(litColor,
+                                albedo,
+                                emissive,
+                                lightingNormal,
+                                viewDir,
+                                nDotL,
+                                ambientOcclusion,
+                                textureLine,
+                                cartoonIntensity);
     }
     return float4(litColor, alpha);
 }


### PR DESCRIPTION
## Summary
- Reworked the planet toon pass to favor illustrated, texture-driven shading instead of broad lighting bands.
- Added posterized color treatment, stronger silhouette inking, and texture-edge line detection for crater/detail outlines.
- Kept the existing internal `cartoonShaderIntensity` control and threaded it through the planet render path.
- Documented the new parameter in `DebugPanelParameters.md`.

Resolves #187 

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`