### PR TITLE
Center transfer overview on Earth

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/MetalProvider.swift
+++ b/Modules/MetalModule/Sources/MetalModule/MetalProvider.swift
@@ -13,8 +13,10 @@ public final class MetalProvider {
 
     let modelLoader: ModelLoader
     let device: MTLDevice
+    weak var renderer: MetalRenderer?
 
     public var isReady: Bool = false
+    public var transferOrbitSummary: TransferOrbitSummary?
 
     public init(modelLoader: ModelLoader) {
         self.modelLoader = modelLoader
@@ -28,5 +30,9 @@ public final class MetalProvider {
         guard !isReady else { return }
         await modelLoader.loadMeshes(device: device)
         isReady = true
+    }
+
+    public func showTransferOrbit(to destinationName: String) {
+        renderer?.showTransferOrbit(to: destinationName)
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Models/HohmannTransferOrbit.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Models/HohmannTransferOrbit.swift
@@ -1,0 +1,119 @@
+//
+//  HohmannTransferOrbit.swift
+//  MetalModule
+//
+//  Created by Codex on 05.05.2026.
+//
+
+import simd
+
+struct HohmannTransferOrbit: Equatable, Sendable {
+    let destinationName: String
+    let earthOrbitRadius: Float
+    let destinationOrbitRadius: Float
+    let semiMajorAxis: Float
+    let sunPosition: SIMD3<Float>
+    let points: [SIMD3<Float>]
+    let summary: TransferOrbitSummary
+
+    static func make(destinationName: String,
+                     planets: [Planet],
+                     earthSunDirection: SIMD3<Float>,
+                     sunPosition: SIMD3<Float> = .zero,
+                     sampleCount: Int = 192) -> HohmannTransferOrbit? {
+        guard sampleCount >= 2,
+              let earth = planets.first(where: { $0.name == "Earth" }),
+              let destination = planets.first(where: { $0.name == destinationName }),
+              isSupportedDestination(destination),
+              earth.distance > 0,
+              destination.distance > 0,
+              simd_length_squared(earthSunDirection) > 0.000001 else {
+            return nil
+        }
+
+        let earthOrbitRadius = earth.distance
+        let destinationOrbitRadius = destination.distance
+        let semiMajorAxis = (earthOrbitRadius + destinationOrbitRadius) / 2
+        let sampledPoints = makeArcPoints(earthOrbitRadius: earthOrbitRadius,
+                                          destinationOrbitRadius: destinationOrbitRadius,
+                                          earthSunDirection: earthSunDirection,
+                                          sampleCount: sampleCount)
+
+        return HohmannTransferOrbit(
+            destinationName: destinationName,
+            earthOrbitRadius: earthOrbitRadius,
+            destinationOrbitRadius: destinationOrbitRadius,
+            semiMajorAxis: semiMajorAxis,
+            sunPosition: sunPosition,
+            points: sampledPoints.map { $0 + sunPosition },
+            summary: TransferOrbitSummary(
+                destinationName: destinationName,
+                earthOrbitRadiusAU: 1,
+                destinationOrbitRadiusAU: destinationOrbitRadius / earthOrbitRadius,
+                semiMajorAxisAU: semiMajorAxis / earthOrbitRadius
+            )
+        )
+    }
+
+    private static func isSupportedDestination(_ planet: Planet) -> Bool {
+        planet.name != "Sun" &&
+        planet.name != "Earth" &&
+        planet.parentName == nil
+    }
+
+    private static func makeArcPoints(earthOrbitRadius: Float,
+                                      destinationOrbitRadius: Float,
+                                      earthSunDirection: SIMD3<Float>,
+                                      sampleCount: Int) -> [SIMD3<Float>] {
+        let innerRadius = min(earthOrbitRadius, destinationOrbitRadius)
+        let outerRadius = max(earthOrbitRadius, destinationOrbitRadius)
+        let eccentricity = (outerRadius - innerRadius) / (outerRadius + innerRadius)
+        let semiLatusRectum = 2 * innerRadius * outerRadius / (innerRadius + outerRadius)
+        let isOutwardTransfer = destinationOrbitRadius >= earthOrbitRadius
+        let departureTrueAnomaly: Float = isOutwardTransfer ? 0 : .pi
+        let destinationTrueAnomaly: Float = isOutwardTransfer ? .pi : 0
+        let departureReferencePoint = point(trueAnomaly: departureTrueAnomaly,
+                                            eccentricity: eccentricity,
+                                            semiLatusRectum: semiLatusRectum)
+        let rotationAngle = signedAngle(from: departureReferencePoint,
+                                        to: earthSunDirection)
+
+        return (0..<sampleCount).map { index in
+            let progress = Float(index) / Float(sampleCount - 1)
+            let trueAnomaly = departureTrueAnomaly +
+            (destinationTrueAnomaly - departureTrueAnomaly) * progress
+            return rotateZ(point(trueAnomaly: trueAnomaly,
+                                 eccentricity: eccentricity,
+                                 semiLatusRectum: semiLatusRectum),
+                           angle: rotationAngle)
+        }
+    }
+
+    private static func point(trueAnomaly: Float,
+                              eccentricity: Float,
+                              semiLatusRectum: Float) -> SIMD3<Float> {
+        let radius = semiLatusRectum / (1 + eccentricity * cos(trueAnomaly))
+        return SIMD3<Float>(radius * cos(trueAnomaly),
+                            radius * sin(trueAnomaly),
+                            0)
+    }
+
+    private static func signedAngle(from source: SIMD3<Float>,
+                                    to destination: SIMD3<Float>) -> Float {
+        let sourceXY = normalize(SIMD2<Float>(source.x, source.y))
+        let destinationXY = normalize(SIMD2<Float>(destination.x, destination.y))
+        let crossValue = sourceXY.x * destinationXY.y - sourceXY.y * destinationXY.x
+        let dotValue = simd_clamp(simd_dot(sourceXY, destinationXY), -1, 1)
+        return atan2(crossValue, dotValue)
+    }
+
+    private static func rotateZ(_ point: SIMD3<Float>, angle: Float) -> SIMD3<Float> {
+        let cosine = cos(angle)
+        let sine = sin(angle)
+        return SIMD3<Float>(
+            point.x * cosine - point.y * sine,
+            point.x * sine + point.y * cosine,
+            point.z
+        )
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Models/TransferOrbitSummary.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Models/TransferOrbitSummary.swift
@@ -1,0 +1,13 @@
+//
+//  TransferOrbitSummary.swift
+//  MetalModule
+//
+//  Created by Codex on 05.05.2026.
+//
+
+public struct TransferOrbitSummary: Equatable, Sendable {
+    public let destinationName: String
+    public let earthOrbitRadiusAU: Float
+    public let destinationOrbitRadiusAU: Float
+    public let semiMajorAxisAU: Float
+}

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
@@ -17,7 +17,8 @@ extension MetalRenderer {
     func drawFirstPass(msaaColorTexture: MTLTexture,
                        hdrTexture: MTLTexture,
                        depthTexture: MTLTexture,
-                       snapshot: PreparedRenderSnapshot?) throws(DrawFirstPassError) {
+                       snapshot: PreparedRenderSnapshot?,
+                       transferOrbit: HohmannTransferOrbit?) throws(DrawFirstPassError) {
 
         guard let geometryCommandBuffer = commandQueue
             .makeCommandBuffer() else {
@@ -53,6 +54,11 @@ extension MetalRenderer {
                              viewMatrix: renderViewMatrix,
                              projectionMatrix: projectionMatrix,
                              sceneOrigin: renderOrigin)
+        transferOrbitRenderer.render(transferOrbit: transferOrbit,
+                                     renderEncoder: renderEncoder,
+                                     viewMatrix: renderViewMatrix,
+                                     projectionMatrix: projectionMatrix,
+                                     sceneOrigin: renderOrigin)
         // Render the remaining planets.
         planetsRenderer.renderPlanets(configuration: configuration)
         renderEncoder.endEncoding()

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -40,6 +40,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         static let verticalFieldOfView: Float = .pi / 3
         static let viewportFill: Float = 0.84
         static let defaultNearPlane: Float = 0.1
+        static let defaultFarPlane: Float = 10000
         static let minimumNearPlane: Float = 0.0005
     }
 
@@ -60,6 +61,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     let commandQueue: MTLCommandQueue
     let planetsRenderer: PlanetsRenderer
     let starsRenderer: StarsRenderer
+    let transferOrbitRenderer: TransferOrbitRenderer
     private let renderPreparationPipeline: RenderPreparationPipeline
     let metalView: MTKView
     let depthStencilState: MTLDepthStencilState
@@ -92,6 +94,9 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private var cameraOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
     private var followingPlanetName: String? = "Sun"
     private var pendingFollowPlanetName: String?
+    private var pendingSelectedPlanetName: String?
+    private var activeTransferDestinationName: String?
+    private var activeTransferOrbit: HohmannTransferOrbit?
 
     // Camera animation state
     private var startCameraTarget: SIMD3<Float>?
@@ -101,7 +106,8 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private var cameraAnimationProgress: Float = 1
     private let cameraAnimationDuration: Float = 1.0
 
-    private let metalProvider: MetalProvider
+    let metalProvider: MetalProvider
+    private let planets: [Planet]
 
     private var viewMatrix: float4x4 {
         didSet {
@@ -132,8 +138,10 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         self.depthStencilState = depthStencilState
         let viewSampleCount = metalView.sampleCount > 1 ? metalView.sampleCount : 4
         let planets = SolarSystemLoader.loadPlanets(from: "planets")
+        self.planets = planets
         planetsRenderer = PlanetsRenderer(device: device, sampleCount: viewSampleCount)
         starsRenderer = StarsRenderer(device: device, sampleCount: viewSampleCount)
+        transferOrbitRenderer = TransferOrbitRenderer(device: device, sampleCount: viewSampleCount)
         renderPreparationPipeline = RenderPreparationPipeline(modelLoader: metalProvider.modelLoader,
                                                               planets: planets)
 
@@ -209,14 +217,26 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         renderPreparationPipeline.requestPreparation(simulationTime: planetsRenderer.currentTime)
         let snapshot = renderPreparationPipeline.latestSnapshot
 
-        if let name = pendingFollowPlanetName,
-           let snapshot,
-           startFollowAnimation(named: name, snapshot: snapshot) {
-            pendingFollowPlanetName = nil
+        if let snapshot {
+            if let name = pendingSelectedPlanetName,
+               applySelectedPlanet(named: name, snapshot: snapshot) {
+                pendingSelectedPlanetName = nil
+            } else {
+                updateActiveTransferOrbit(snapshot: snapshot)
+            }
+
+            if let name = pendingFollowPlanetName,
+               startFollowAnimation(named: name, snapshot: snapshot) {
+                pendingFollowPlanetName = nil
+            }
         }
 
         if cameraAnimationProgress < 1 {
             updateCameraAnimation(delta: delta)
+        } else if activeTransferOrbit != nil,
+                  let earthPosition = snapshot?.worldPosition(ofPlanetNamed: "Earth") {
+            cameraTarget = earthPosition
+            updateCamera()
         } else if let name = followingPlanetName,
                   let position = snapshot?.worldPosition(ofPlanetNamed: name) {
             cameraTarget = position
@@ -227,7 +247,8 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             try drawFirstPass(msaaColorTexture: msaaColorTexture,
                               hdrTexture: hdrTexture,
                               depthTexture: depthTexture,
-                              snapshot: snapshot)
+                              snapshot: snapshot,
+                              transferOrbit: activeTransferOrbit)
             drawSecondPass(postfxMsaaTexture: postfxMsaaTexture,
                            drawable: drawable,
                            hdrTexture: hdrTexture)
@@ -242,7 +263,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             fov: CameraFit.verticalFieldOfView,
             aspect: aspect,
             near: nearPlaneDistance(),
-            far: 10000
+            far: farPlaneDistance()
         )
     }
 
@@ -250,6 +271,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     /// The camera moves smoothly to the planet's position and adjusts
     /// distance based on the planet's radius.
     func followPlanet(named name: String) {
+        clearTransferOrbit()
         followingPlanetName = name
 
         guard let snapshot = renderPreparationPipeline.latestSnapshot,
@@ -260,6 +282,120 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         }
 
         pendingFollowPlanetName = nil
+    }
+
+    func showTransferOrbit(to name: String) {
+        guard let snapshot = renderPreparationPipeline.latestSnapshot,
+              applySelectedPlanet(named: name, snapshot: snapshot) else {
+            pendingSelectedPlanetName = name
+            cameraAnimationProgress = 1
+            return
+        }
+    }
+
+    private func applySelectedPlanet(named name: String,
+                                     snapshot: PreparedRenderSnapshot) -> Bool {
+        guard let transferOrbit = makeTransferOrbit(destinationName: name,
+                                                    snapshot: snapshot) else {
+            clearTransferOrbit()
+            followingPlanetName = name
+            pendingFollowPlanetName = nil
+            return startFollowAnimation(named: name, snapshot: snapshot)
+        }
+
+        activeTransferDestinationName = name
+        activeTransferOrbit = transferOrbit
+        publishTransferOrbitSummary(transferOrbit.summary)
+        followingPlanetName = "Earth"
+        pendingFollowPlanetName = nil
+        startTransferOverviewAnimation(transferOrbit: transferOrbit,
+                                       snapshot: snapshot)
+        return true
+    }
+
+    private func updateActiveTransferOrbit(snapshot: PreparedRenderSnapshot) {
+        guard let activeTransferDestinationName else { return }
+
+        guard let transferOrbit = makeTransferOrbit(destinationName: activeTransferDestinationName,
+                                                    snapshot: snapshot) else {
+            clearTransferOrbit()
+            return
+        }
+
+        activeTransferOrbit = transferOrbit
+        publishTransferOrbitSummary(transferOrbit.summary)
+    }
+
+    private func makeTransferOrbit(destinationName: String,
+                                   snapshot: PreparedRenderSnapshot) -> HohmannTransferOrbit? {
+        guard let sunPosition = snapshot.worldPosition(ofPlanetNamed: "Sun"),
+              let earthPosition = snapshot.worldPosition(ofPlanetNamed: "Earth") else {
+            return nil
+        }
+
+        return HohmannTransferOrbit.make(destinationName: destinationName,
+                                         planets: planets,
+                                         earthSunDirection: earthPosition - sunPosition,
+                                         sunPosition: sunPosition)
+    }
+
+    private func clearTransferOrbit() {
+        pendingSelectedPlanetName = nil
+        activeTransferDestinationName = nil
+        activeTransferOrbit = nil
+        publishTransferOrbitSummary(nil)
+    }
+
+    private func publishTransferOrbitSummary(_ summary: TransferOrbitSummary?) {
+        guard metalProvider.transferOrbitSummary != summary else { return }
+        metalProvider.transferOrbitSummary = summary
+    }
+
+    private func startTransferOverviewAnimation(transferOrbit: HohmannTransferOrbit,
+                                                snapshot: PreparedRenderSnapshot) {
+        guard let framing = earthCenteredTransferFraming(transferOrbit: transferOrbit,
+                                                         snapshot: snapshot) else {
+            return
+        }
+
+        startCameraTarget = cameraTarget
+        endCameraTarget = framing.center
+        startCameraDistance = cameraDistance
+        endCameraDistance = distanceToFitPlanet(radius: framing.radius) * 1.08
+        cameraAnimationProgress = 0
+    }
+
+    private func earthCenteredTransferFraming(transferOrbit: HohmannTransferOrbit,
+                                              snapshot: PreparedRenderSnapshot)
+    -> (center: SIMD3<Float>, radius: Float)? {
+        guard let earthPosition = snapshot.worldPosition(ofPlanetNamed: "Earth") else {
+            return nil
+        }
+
+        var framingRadius: Float = 0
+        func include(center: SIMD3<Float>, radius: Float) {
+            framingRadius = max(framingRadius,
+                                simd_distance(earthPosition, center) + max(radius, 0))
+        }
+
+        for point in transferOrbit.points {
+            include(center: point, radius: 0)
+        }
+
+        include(center: transferOrbit.sunPosition,
+                radius: max(transferOrbit.earthOrbitRadius,
+                            transferOrbit.destinationOrbitRadius))
+
+        for planetName in ["Sun", "Earth", transferOrbit.destinationName] {
+            guard let planetPosition = snapshot.worldPosition(ofPlanetNamed: planetName) else {
+                continue
+            }
+            include(center: planetPosition,
+                    radius: snapshot.framingRadius(ofPlanetNamed: planetName) ?? 0)
+        }
+
+        guard framingRadius.isFinite else { return nil }
+        return (earthPosition, max(framingRadius, 0.001))
     }
 
     /// Stops any active camera interpolation so direct gestures manipulate
@@ -382,6 +518,48 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         let frontClearance = max(cameraDistance - framingRadius, CameraFit.minimumNearPlane * 2)
         return min(CameraFit.defaultNearPlane,
                    max(CameraFit.minimumNearPlane, frontClearance * 0.5))
+    }
+
+    private func farPlaneDistance() -> Float {
+        guard let activeTransferOrbit,
+              let snapshot = renderPreparationPipeline.latestSnapshot,
+              let transferRadius = transferProjectionRadius(transferOrbit: activeTransferOrbit,
+                                                            snapshot: snapshot) else {
+            return CameraFit.defaultFarPlane
+        }
+
+        return max(CameraFit.defaultFarPlane,
+                   cameraDistance + transferRadius * 1.15)
+    }
+
+    private func transferProjectionRadius(transferOrbit: HohmannTransferOrbit,
+                                          snapshot: PreparedRenderSnapshot) -> Float? {
+        var radius: Float = 0
+
+        func include(center: SIMD3<Float>, radius includedRadius: Float) {
+            radius = max(radius,
+                         simd_distance(cameraTarget, center) + max(includedRadius, 0))
+        }
+
+        for point in transferOrbit.points {
+            include(center: point, radius: 0)
+        }
+
+        include(center: transferOrbit.sunPosition,
+                radius: max(transferOrbit.earthOrbitRadius,
+                            transferOrbit.destinationOrbitRadius))
+
+        for planetName in ["Sun", "Earth", transferOrbit.destinationName] {
+            guard let planetPosition = snapshot.worldPosition(ofPlanetNamed: planetName) else {
+                continue
+            }
+
+            include(center: planetPosition,
+                    radius: snapshot.framingRadius(ofPlanetNamed: planetName) ?? 0)
+        }
+
+        guard radius.isFinite else { return nil }
+        return max(radius, 0.001)
     }
 
     func applyPostFXStyle(_ style: PostFXStyle) {

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/TransferOrbitRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/TransferOrbitRenderer.swift
@@ -1,0 +1,177 @@
+//
+//  TransferOrbitRenderer.swift
+//  MetalModule
+//
+//  Created by Codex on 05.05.2026.
+//
+
+import Metal
+import simd
+
+final class TransferOrbitRenderer {
+    private static let colorPixelFormat: MTLPixelFormat = .rgba16Float
+    private static let depthPixelFormat: MTLPixelFormat = .depth32Float
+
+    private let device: MTLDevice
+    private let pipelineState: MTLRenderPipelineState
+    private let depthStencilState: MTLDepthStencilState
+
+    init(device: MTLDevice, sampleCount: Int) {
+        self.device = device
+        pipelineState = Self.makePipelineState(device: device,
+                                               sampleCount: sampleCount)
+        depthStencilState = Self.makeDepthStencilState(device: device)
+    }
+
+    func render(transferOrbit: HohmannTransferOrbit?,
+                renderEncoder: MTLRenderCommandEncoder,
+                viewMatrix: float4x4,
+                projectionMatrix: float4x4,
+                sceneOrigin: SIMD3<Float>) {
+        guard let transferOrbit,
+              transferOrbit.points.count >= 2 else { return }
+
+        let context = RenderContext(renderEncoder: renderEncoder,
+                                    viewMatrix: viewMatrix,
+                                    projectionMatrix: projectionMatrix,
+                                    sceneOrigin: sceneOrigin)
+        renderLine(points: circlePoints(center: transferOrbit.sunPosition,
+                                        radius: transferOrbit.earthOrbitRadius),
+                   color: SIMD4<Float>(0.26, 0.55, 1.0, 0.72),
+                   dashFrequency: 72,
+                   dashDuty: 0.48,
+                   context: context)
+        renderLine(points: circlePoints(center: transferOrbit.sunPosition,
+                                        radius: transferOrbit.destinationOrbitRadius),
+                   color: SIMD4<Float>(1.0, 0.62, 0.22, 0.72),
+                   dashFrequency: 92,
+                   dashDuty: 0.48,
+                   context: context)
+        renderLine(points: transferOrbit.points,
+                   color: SIMD4<Float>(0.2, 0.82, 1.0, 1.0),
+                   dashFrequency: 0,
+                   dashDuty: 1,
+                   context: context)
+    }
+
+    private func renderLine(points: [SIMD3<Float>],
+                            color: SIMD4<Float>,
+                            dashFrequency: Float,
+                            dashDuty: Float,
+                            context: RenderContext) {
+        guard points.count >= 2 else { return }
+
+        let vertices = makeVertices(points: points)
+        guard let vertexBuffer = device.makeBuffer(bytes: vertices,
+                                                   length: MemoryLayout<TransferOrbitVertex>.stride * vertices.count,
+                                                   options: .storageModeShared) else {
+            return
+        }
+
+        var uniforms = TransferOrbitUniforms(
+            viewMatrix: context.viewMatrix,
+            projectionMatrix: context.projectionMatrix,
+            sceneOriginAndOpacity: SIMD4<Float>(context.sceneOrigin.x,
+                                                context.sceneOrigin.y,
+                                                context.sceneOrigin.z,
+                                                0.95),
+            color: color,
+            dash: SIMD4<Float>(dashFrequency, dashDuty, 0, 0)
+        )
+
+        context.renderEncoder.setRenderPipelineState(pipelineState)
+        context.renderEncoder.setDepthStencilState(depthStencilState)
+        context.renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        context.renderEncoder.setVertexBytes(&uniforms,
+                                             length: MemoryLayout<TransferOrbitUniforms>.stride,
+                                             index: 1)
+        context.renderEncoder.setFragmentBytes(&uniforms,
+                                               length: MemoryLayout<TransferOrbitUniforms>.stride,
+                                               index: 0)
+        context.renderEncoder.drawPrimitives(type: .lineStrip,
+                                             vertexStart: 0,
+                                             vertexCount: vertices.count)
+    }
+
+    private func circlePoints(center: SIMD3<Float>,
+                              radius: Float,
+                              sampleCount: Int = 256) -> [SIMD3<Float>] {
+        guard radius > 0, sampleCount >= 3 else { return [] }
+
+        return (0...sampleCount).map { index in
+            let angle = Float(index) / Float(sampleCount) * 2 * .pi
+            return SIMD3<Float>(center.x + radius * cos(angle),
+                                center.y + radius * sin(angle),
+                                center.z)
+        }
+    }
+
+    private func makeVertices(points: [SIMD3<Float>]) -> [TransferOrbitVertex] {
+        points.enumerated().map { index, point in
+            let progress = Float(index) / Float(max(points.count - 1, 1))
+            return TransferOrbitVertex(positionAndProgress: SIMD4<Float>(point.x,
+                                                                         point.y,
+                                                                         point.z,
+                                                                         progress))
+        }
+    }
+
+    private static func makePipelineState(device: MTLDevice,
+                                          sampleCount: Int) -> MTLRenderPipelineState {
+        let library: MTLLibrary
+        do {
+            library = try device.makeDefaultLibrary(bundle: .module)
+        } catch {
+            fatalError("Failed to load Metal shader library from MetalModule bundle: \(error)")
+        }
+
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.rasterSampleCount = sampleCount
+        descriptor.colorAttachments[0].pixelFormat = Self.colorPixelFormat
+        descriptor.colorAttachments[0].isBlendingEnabled = true
+        descriptor.colorAttachments[0].rgbBlendOperation = .add
+        descriptor.colorAttachments[0].alphaBlendOperation = .add
+        descriptor.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+        descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
+        descriptor.colorAttachments[0].destinationRGBBlendFactor = .one
+        descriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        descriptor.depthAttachmentPixelFormat = Self.depthPixelFormat
+        descriptor.vertexFunction = library.makeFunction(name: "transfer_orbit_vertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "transfer_orbit_fragment")
+
+        do {
+            return try device.makeRenderPipelineState(descriptor: descriptor)
+        } catch {
+            fatalError("Failed to create transfer orbit pipeline state: \(error)")
+        }
+    }
+
+    private static func makeDepthStencilState(device: MTLDevice) -> MTLDepthStencilState {
+        let descriptor = MTLDepthStencilDescriptor()
+        descriptor.depthCompareFunction = .lessEqual
+        descriptor.isDepthWriteEnabled = true
+        guard let state = device.makeDepthStencilState(descriptor: descriptor) else {
+            fatalError("Failed to create transfer orbit depth stencil state")
+        }
+        return state
+    }
+}
+
+private struct TransferOrbitVertex {
+    var positionAndProgress: SIMD4<Float>
+}
+
+private struct RenderContext {
+    let renderEncoder: MTLRenderCommandEncoder
+    let viewMatrix: float4x4
+    let projectionMatrix: float4x4
+    let sceneOrigin: SIMD3<Float>
+}
+
+private struct TransferOrbitUniforms {
+    var viewMatrix: float4x4
+    var projectionMatrix: float4x4
+    var sceneOriginAndOpacity: SIMD4<Float>
+    var color: SIMD4<Float>
+    var dash: SIMD4<Float>
+}

--- a/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
+++ b/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
@@ -227,6 +227,52 @@ fragment float4 star_fragment(StarVertexOut in [[stage_in]],
     return float4(color, alpha);
 }
 
+struct TransferOrbitVertexIn {
+    float4 positionAndProgress;
+};
+
+struct TransferOrbitUniforms {
+    float4x4 viewMatrix;
+    float4x4 projectionMatrix;
+    float4 sceneOriginAndOpacity;
+    float4 color;
+    float4 dash;
+};
+
+struct TransferOrbitVertexOut {
+    float4 position [[position]];
+    float progress;
+};
+
+vertex TransferOrbitVertexOut transfer_orbit_vertex(
+                                                    const device TransferOrbitVertexIn *vertices [[buffer(0)]],
+                                                    constant TransferOrbitUniforms &uniforms [[buffer(1)]],
+                                                    uint vid [[vertex_id]]
+                                                    ) {
+    TransferOrbitVertexIn orbitVertex = vertices[vid];
+    float3 sceneOrigin = uniforms.sceneOriginAndOpacity.xyz;
+    float3 localPosition = orbitVertex.positionAndProgress.xyz - sceneOrigin;
+
+    TransferOrbitVertexOut out;
+    out.position = uniforms.projectionMatrix * uniforms.viewMatrix * float4(localPosition, 1.0);
+    out.progress = orbitVertex.positionAndProgress.w;
+    return out;
+}
+
+fragment float4 transfer_orbit_fragment(TransferOrbitVertexOut in [[stage_in]],
+                                        constant TransferOrbitUniforms &uniforms [[buffer(0)]]) {
+    if (uniforms.dash.x > 0.0) {
+        float dashPhase = fract(in.progress * uniforms.dash.x);
+        if (dashPhase > uniforms.dash.y) {
+            discard_fragment();
+        }
+    }
+
+    float pulse = 0.76 + 0.24 * sin(in.progress * 3.14159265);
+    float alpha = uniforms.color.a * uniforms.sceneOriginAndOpacity.w;
+    return float4(uniforms.color.rgb * pulse, alpha);
+}
+
 fragment float4 fragment_main(VertexOut in [[stage_in]],
                               texture2d<float> planetTexture [[texture(0)]],
                               texture2d<float> normalTexture [[texture(1)]],

--- a/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
+++ b/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
@@ -42,6 +42,7 @@ public struct UniverseView: UIViewRepresentable {
         // Initialize renderer and delegate
         let renderer = MetalRenderer(metalView: mtkView, metalProvider: metalProvider)
         context.coordinator.renderer = renderer
+        metalProvider.renderer = renderer
         renderer?.labelDelegate = context.coordinator
 
         // Camera controller
@@ -82,5 +83,6 @@ public struct UniverseView: UIViewRepresentable {
 
     public static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
         coordinator.cameraController?.stop()
+        coordinator.renderer?.metalProvider.renderer = nil
     }
 }

--- a/Modules/MetalModule/Tests/MetalModuleTests/MetalModuleTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/MetalModuleTests.swift
@@ -2,6 +2,111 @@ import simd
 import Testing
 @testable import MetalModule
 
+private let testPlanets: [Planet] = [
+    Planet(name: "Sun",
+           meshName: "Sun",
+           parentName: nil,
+           radius: 1,
+           distance: 0,
+           orbitSpeed: 0,
+           rotationSpeedKmSec: 0),
+    Planet(name: "Mercury",
+           meshName: "Mercury",
+           parentName: nil,
+           radius: 1,
+           distance: 0.38,
+           orbitSpeed: 0,
+           rotationSpeedKmSec: 0),
+    Planet(name: "Earth",
+           meshName: "Earth",
+           parentName: nil,
+           radius: 1,
+           distance: 1,
+           orbitSpeed: 0,
+           rotationSpeedKmSec: 0),
+    Planet(name: "Moon",
+           meshName: "Moon",
+           parentName: "Earth",
+           radius: 1,
+           distance: 0.0025,
+           orbitSpeed: 0,
+           rotationSpeedKmSec: 0),
+    Planet(name: "Mars",
+           meshName: "Mars",
+           parentName: nil,
+           radius: 1,
+           distance: 1.52,
+           orbitSpeed: 0,
+           rotationSpeedKmSec: 0)
+]
+
+@Test func hohmannSemiMajorAxisUsesMeanOrbitRadius() {
+    let transfer = HohmannTransferOrbit.make(destinationName: "Mars",
+                                             planets: testPlanets,
+                                             earthSunDirection: SIMD3<Float>(1, 0, 0),
+                                             sampleCount: 16)
+
+    #expect(abs((transfer?.semiMajorAxis ?? 0) - 1.26) < 0.0001)
+    #expect(abs((transfer?.summary.semiMajorAxisAU ?? 0) - 1.26) < 0.0001)
+}
+
+@Test func outwardTransferStartsAtEarthAndEndsAtDestinationRadius() throws {
+    let transfer = try #require(HohmannTransferOrbit.make(
+        destinationName: "Mars",
+        planets: testPlanets,
+        earthSunDirection: SIMD3<Float>(1, 0, 0),
+        sampleCount: 16
+    ))
+
+    let firstPoint = try #require(transfer.points.first)
+    let lastPoint = try #require(transfer.points.last)
+
+    #expect(abs(simd_length(firstPoint) - 1) < 0.0001)
+    #expect(abs(simd_length(lastPoint) - 1.52) < 0.0001)
+    #expect(lastPoint.x < 0)
+}
+
+@Test func inwardTransferStartsAtEarthAndEndsAtInnerDestinationRadius() throws {
+    let transfer = try #require(HohmannTransferOrbit.make(
+        destinationName: "Mercury",
+        planets: testPlanets,
+        earthSunDirection: SIMD3<Float>(1, 0, 0),
+        sampleCount: 16
+    ))
+
+    let firstPoint = try #require(transfer.points.first)
+    let lastPoint = try #require(transfer.points.last)
+
+    #expect(abs(simd_length(firstPoint) - 1) < 0.0001)
+    #expect(abs(simd_length(lastPoint) - 0.38) < 0.0001)
+}
+
+@Test func transferArcRotatesFirstPointToEarthDirection() throws {
+    let earthDirection = normalize(SIMD3<Float>(0.25, 0.75, 0))
+    let transfer = try #require(HohmannTransferOrbit.make(
+        destinationName: "Mars",
+        planets: testPlanets,
+        earthSunDirection: earthDirection,
+        sampleCount: 16
+    ))
+
+    let firstPoint = normalize(try #require(transfer.points.first))
+
+    #expect(simd_distance(firstPoint, earthDirection) < 0.0001)
+}
+
+@Test func unsupportedTransferTargetsReturnNil() {
+    #expect(HohmannTransferOrbit.make(destinationName: "Sun",
+                                     planets: testPlanets,
+                                     earthSunDirection: SIMD3<Float>(1, 0, 0)) == nil)
+    #expect(HohmannTransferOrbit.make(destinationName: "Moon",
+                                     planets: testPlanets,
+                                     earthSunDirection: SIMD3<Float>(1, 0, 0)) == nil)
+    #expect(HohmannTransferOrbit.make(destinationName: "Earth",
+                                     planets: testPlanets,
+                                     earthSunDirection: SIMD3<Float>(1, 0, 0)) == nil)
+}
+
 @Test func generatedStarsAreDeterministicForSeed() {
     let configuration = StarFieldConfiguration(
         density: 0.02,

--- a/OptiUniverse/Features/RootContainer/RootContainerView.swift
+++ b/OptiUniverse/Features/RootContainer/RootContainerView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MetalModule
 import BaseModule
+import Foundation
 
 struct RootContainerView: View {
 
@@ -35,13 +36,80 @@ struct RootContainerView: View {
             case (true, .home):
                 HomeView()
             case (true, .objects):
-                UniverseView(metalProvider: metalProvider)
-                    .ignoresSafeArea(edges: .bottom)
+                ZStack {
+                    UniverseView(metalProvider: metalProvider)
+                        .ignoresSafeArea(edges: .bottom)
+
+                    if let summary = metalProvider.transferOrbitSummary {
+                        TransferOrbitFormulaOverlay(summary: summary)
+                            .padding(.top, 12)
+                            .padding(.horizontal, 16)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                            .frame(maxWidth: .infinity,
+                                   maxHeight: .infinity,
+                                   alignment: .topTrailing)
+                    }
+
+                    if let selectedPlanet = appEnvironment.selectedPlanet {
+                        Button {
+                            metalProvider.showTransferOrbit(to: selectedPlanet)
+                        } label: {
+                            Text("Navigate to")
+                                .font(.headline.weight(.semibold))
+                                .foregroundStyle(.black)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 15)
+                        }
+                        .background(.white, in: RoundedRectangle(cornerRadius: 8))
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: .infinity,
+                               maxHeight: .infinity,
+                               alignment: .bottom)
+                    }
+                }
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: metalProvider.transferOrbitSummary)
         .task {
             await metalProvider.prepare()
         }
+    }
+}
+
+private struct TransferOrbitFormulaOverlay: View {
+    let summary: TransferOrbitSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Hohmann transfer")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.72))
+
+            Text("a = (r1 + r2) / 2")
+                .font(.system(.callout, design: .monospaced).weight(.semibold))
+                .foregroundStyle(.white)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("r1 Earth: \(formatted(summary.earthOrbitRadiusAU)) AU")
+                Text("r2 \(summary.destinationName): \(formatted(summary.destinationOrbitRadiusAU)) AU")
+                Text("a: \(formatted(summary.semiMajorAxisAU)) AU")
+            }
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.white.opacity(0.82))
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(.black.opacity(0.58), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.white.opacity(0.16), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private func formatted(_ value: Float) -> String {
+        String(format: "%.3f", Double(value))
     }
 }
 


### PR DESCRIPTION
## Summary
- Recentered the Hohmann transfer overview on Earth instead of the Sun.
- The camera now frames the transfer around Earth as the active departure point while the orbit geometry stays Sun-centered.
- The transfer view continues to track Earth as the simulation advances.

Resolves #218

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO` passed.
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO` passed.