### PR TITLE
Add two-finger trajectory panning to the transfer view

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/CameraController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/CameraController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Handles user gestures to control the orbital camera around the scene's origin.
 @MainActor
-final class CameraController: NSObject {
+final class CameraController: NSObject, UIGestureRecognizerDelegate {
     weak var renderer: MetalRenderer?
 
     // Tunable parameters
@@ -10,6 +10,7 @@ final class CameraController: NSObject {
     var zoomSpeed: Float
     var minDistance: Float
     var maxDistance: Float
+    var trajectoryPanSpeed: Float
 
     // Internal state for inertia
     private var yawVelocity: Float = 0
@@ -21,11 +22,13 @@ final class CameraController: NSObject {
     init(renderer: MetalRenderer?,
          orbitSpeed: Float = 0.01,
          zoomSpeed: Float = 1.0,
+         trajectoryPanSpeed: Float = 1.0,
          minDistance: Float = 0.001,
          maxDistance: Float = 10000.0) {
         self.renderer = renderer
         self.orbitSpeed = orbitSpeed
         self.zoomSpeed = zoomSpeed
+        self.trajectoryPanSpeed = trajectoryPanSpeed
         self.minDistance = minDistance
         self.maxDistance = maxDistance
         super.init()
@@ -93,6 +96,24 @@ final class CameraController: NSObject {
         }
     }
 
+    @objc func handleTrajectoryPan(_ gesture: UIPanGestureRecognizer) {
+        guard let renderer = renderer else { return }
+        renderer.beginManualCameraControl()
+
+        if gesture.state == .began {
+            stopInertia()
+        }
+
+        let translation = gesture.translation(in: gesture.view)
+        renderer.panTrajectoryCamera(byScreenTranslation: translation,
+                                     speed: trajectoryPanSpeed)
+        gesture.setTranslation(.zero, in: gesture.view)
+
+        if gesture.state == .cancelled || gesture.state == .failed {
+            stopInertia()
+        }
+    }
+
     @objc func handlePinch(_ gesture: UIPinchGestureRecognizer) {
         guard let renderer = renderer else { return }
         renderer.beginManualCameraControl()
@@ -124,5 +145,14 @@ final class CameraController: NSObject {
 
     @objc func handleRotation(_ gesture: UIRotationGestureRecognizer) {
         // Optional roll gesture – renderer currently has no roll component.
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer,
+              panGesture.minimumNumberOfTouches == 2 else {
+            return true
+        }
+
+        return renderer?.isTrajectoryModeActive == true
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -97,6 +97,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private var pendingSelectedPlanetName: String?
     private var activeTransferDestinationName: String?
     private var activeTransferOrbit: HohmannTransferOrbit?
+    private var transferCameraTargetOffset = SIMD3<Float>(repeating: 0)
 
     // Camera animation state
     private var startCameraTarget: SIMD3<Float>?
@@ -118,6 +119,9 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         didSet {
             projectionMatrixLogger.logChange(from: oldValue, to: projectionMatrix)
         }
+    }
+    var isTrajectoryModeActive: Bool {
+        activeTransferOrbit != nil
     }
 
     init?(metalView: MTKView, metalProvider: MetalProvider) {
@@ -235,7 +239,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             updateCameraAnimation(delta: delta)
         } else if activeTransferOrbit != nil,
                   let earthPosition = snapshot?.worldPosition(ofPlanetNamed: "Earth") {
-            cameraTarget = earthPosition
+            cameraTarget = earthPosition + transferCameraTargetOffset
             updateCamera()
         } else if let name = followingPlanetName,
                   let position = snapshot?.worldPosition(ofPlanetNamed: name) {
@@ -305,6 +309,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
         activeTransferDestinationName = name
         activeTransferOrbit = transferOrbit
+        transferCameraTargetOffset = .zero
         publishTransferOrbitSummary(transferOrbit.summary)
         followingPlanetName = "Earth"
         pendingFollowPlanetName = nil
@@ -343,6 +348,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         pendingSelectedPlanetName = nil
         activeTransferDestinationName = nil
         activeTransferOrbit = nil
+        transferCameraTargetOffset = .zero
         publishTransferOrbitSummary(nil)
     }
 
@@ -401,6 +407,12 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     /// Stops any active camera interpolation so direct gestures manipulate
     /// distance/orbit immediately without being overridden on the next frame.
     func beginManualCameraControl() {
+        if activeTransferOrbit != nil,
+           let earthPosition = renderPreparationPipeline.latestSnapshot?
+            .worldPosition(ofPlanetNamed: "Earth") {
+            transferCameraTargetOffset = cameraTarget - earthPosition
+        }
+
         pendingFollowPlanetName = nil
         cameraAnimationProgress = 1
         startCameraTarget = nil
@@ -491,6 +503,30 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         let verticalRotation = simd_quatf(angle: verticalAngle, axis: rightVector)
 
         cameraOrientation = simd_normalize(verticalRotation * horizontalRotation * cameraOrientation)
+    }
+
+    func panTrajectoryCamera(byScreenTranslation translation: CGPoint,
+                             speed: Float) {
+        guard activeTransferOrbit != nil else { return }
+
+        cameraOrientation = simd_normalize(cameraOrientation)
+
+        let width = max(Float(metalView.bounds.width), 1)
+        let height = max(Float(metalView.bounds.height), 1)
+        let aspect = width / height
+        let visibleHeight = (
+            2 * max(cameraDistance, CameraFit.minimumNearPlane)
+            * tan(CameraFit.verticalFieldOfView / 2)
+        )
+        let visibleWidth = visibleHeight * aspect
+        let horizontal = Float(translation.x) / width * visibleWidth * speed
+        let vertical = Float(translation.y) / height * visibleHeight * speed
+        let rightVector = normalize(cameraOrientation.act(SIMD3<Float>(1, 0, 0)))
+        let upVector = normalize(cameraOrientation.act(SIMD3<Float>(0, 1, 0)))
+
+        transferCameraTargetOffset += (rightVector * horizontal) + (upVector * vertical)
+        cameraTarget += (rightVector * horizontal) + (upVector * vertical)
+        updateCamera()
     }
 
     private func distanceToFitPlanet(radius: Float) -> Float {

--- a/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
+++ b/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
@@ -53,7 +53,15 @@ public struct UniverseView: UIViewRepresentable {
         let panGesture = UIPanGestureRecognizer(
             target: cameraController,
             action: #selector(CameraController.handlePan(_:)))
+        panGesture.maximumNumberOfTouches = 1
         mtkView.addGestureRecognizer(panGesture)
+        let trajectoryPanGesture = UIPanGestureRecognizer(
+            target: cameraController,
+            action: #selector(CameraController.handleTrajectoryPan(_:)))
+        trajectoryPanGesture.minimumNumberOfTouches = 2
+        trajectoryPanGesture.maximumNumberOfTouches = 2
+        trajectoryPanGesture.delegate = cameraController
+        mtkView.addGestureRecognizer(trajectoryPanGesture)
         let pinchGesture = UIPinchGestureRecognizer(
             target: cameraController,
             action: #selector(CameraController.handlePinch(_:)))


### PR DESCRIPTION
## Summary
- Added a dedicated two-finger pan gesture for trajectory mode while keeping the one-finger orbit pan unchanged.
- Wired trajectory dragging into `MetalRenderer` so the transfer/orbit view can move continuously left, right, up, and down.
- Inverted the horizontal mapping so left/right motion matches the requested direction.

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`