### PR TITLE
Smooth camera transitions for object selection

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/CameraTransition.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/CameraTransition.swift
@@ -1,0 +1,76 @@
+//
+//  CameraTransition.swift
+//  MetalModule
+//
+//  Created by Codex on 13.05.2026.
+//
+
+import simd
+
+struct CameraTransition {
+    struct Frame: Equatable {
+        let target: SIMD3<Float>
+        let distance: Float
+    }
+
+    enum Destination: Equatable {
+        case planet(name: String)
+        case fixed(target: SIMD3<Float>, distance: Float)
+    }
+
+    let start: Frame
+    let destination: Destination
+    let duration: Float
+    private(set) var elapsed: Float = 0
+
+    var progress: Float {
+        guard duration > 0 else { return 1 }
+        return min(max(elapsed / duration, 0), 1)
+    }
+
+    var isComplete: Bool {
+        progress >= 1
+    }
+
+    init(start: Frame,
+         destination: Destination,
+         duration: Float) {
+        self.start = start
+        self.destination = destination
+        self.duration = max(duration, 0.001)
+    }
+
+    mutating func advance(delta: Float,
+                          resolveDestination: (Destination) -> Frame?) -> Frame? {
+        guard let end = resolveDestination(destination) else { return nil }
+
+        elapsed = min(max(elapsed + max(delta, 0), 0), duration)
+        return Self.interpolate(from: start,
+                                to: end,
+                                progress: easedProgress)
+    }
+
+    var easedProgress: Float {
+        Self.easeInOutCubic(progress)
+    }
+
+    static func interpolate(from start: Frame,
+                            to end: Frame,
+                            progress: Float) -> Frame {
+        let clampedProgress = min(max(progress, 0), 1)
+        return Frame(
+            target: start.target + (end.target - start.target) * clampedProgress,
+            distance: start.distance + (end.distance - start.distance) * clampedProgress
+        )
+    }
+
+    static func easeInOutCubic(_ value: Float) -> Float {
+        let clampedValue = min(max(value, 0), 1)
+        if clampedValue < 0.5 {
+            return 4 * clampedValue * clampedValue * clampedValue
+        }
+
+        let inverseProgress = -2 * clampedValue + 2
+        return 1 - (inverseProgress * inverseProgress * inverseProgress) / 2
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+Navigation.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+Navigation.swift
@@ -12,7 +12,7 @@ extension MetalRenderer {
         guard let snapshot = renderPreparationPipeline.latestSnapshot,
               applyNavigation(named: name, snapshot: snapshot) else {
             pendingNavigationDestinationName = name
-            cameraAnimationProgress = 1
+            cameraTransition = nil
             return
         }
 
@@ -45,7 +45,7 @@ extension MetalRenderer {
         guard let snapshot = renderPreparationPipeline.latestSnapshot,
               startFollowAnimation(named: destinationName, snapshot: snapshot) else {
             pendingFollowPlanetName = destinationName
-            cameraAnimationProgress = 1
+            cameraTransition = nil
             return
         }
 
@@ -90,7 +90,7 @@ extension MetalRenderer {
         navigationCameraFollowEnabled = isEnabled
         navigationRenderHandler.navigationCameraFollowEnabled = isEnabled
         if isEnabled {
-            cameraAnimationProgress = 1
+            cameraTransition = nil
         } else if let route = navigationRouteCoordinator.activeRouteForRendering,
                   let snapshot = renderPreparationPipeline.latestSnapshot {
             startNavigationOverviewAnimation(route: route, snapshot: snapshot)
@@ -125,7 +125,7 @@ extension MetalRenderer {
         }
 
         if navigationCameraFollowEnabled {
-            cameraAnimationProgress = 1
+            cameraTransition = nil
             captureNavigationCameraTrailingOffset(route: route, snapshot: snapshot)
             updateNavigationFollowCamera(snapshot: snapshot)
         } else {
@@ -142,11 +142,12 @@ extension MetalRenderer {
             return
         }
 
-        startCameraTarget = cameraTarget
-        endCameraTarget = framing.center
-        startCameraDistance = cameraDistance
-        endCameraDistance = distanceToFitPlanet(radius: framing.radius) * 1.08
-        cameraAnimationProgress = 0
+        cameraTransition = CameraTransition(
+            start: currentCameraTransitionFrame,
+            destination: .fixed(target: framing.center,
+                                distance: distanceToFitPlanet(radius: framing.radius) * 1.08),
+            duration: cameraFollowTransitionDuration
+        )
     }
 
     private func earthCenteredNavigationFraming(route: NavigationRoute,

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -111,13 +111,9 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     let navigationArrivalDuration: Float = 0.9
     let navigationArrivalDistanceMultiplier: Float = 5.8
 
-    // Camera animation state
-    var startCameraTarget: SIMD3<Float>?
-    var endCameraTarget: SIMD3<Float>?
-    var startCameraDistance: Float?
-    var endCameraDistance: Float?
-    var cameraAnimationProgress: Float = 1
-    private let cameraAnimationDuration: Float = 1.0
+    // Camera transition state
+    var cameraTransition: CameraTransition?
+    let cameraFollowTransitionDuration: Float = 1.1
 
     let meshProvider: MeshProvider
     let orbitRenderHandler: OrbitRenderHandlerProtocol
@@ -313,9 +309,10 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                   let snapshot {
             resetNavigationArrivalTransition()
             updateNavigationFollowCamera(snapshot: snapshot)
-        } else if cameraAnimationProgress < 1 {
+        } else if cameraTransition != nil {
             resetNavigationArrivalTransition()
-            updateCameraAnimation(delta: delta)
+            updateCameraTransition(snapshot: snapshot,
+                                   delta: delta)
         } else if activeTransferOrbit != nil,
                   !navigationRouteCoordinator.isNavigationActive,
                   let earthPosition = snapshot?.worldPosition(ofPlanetNamed: "Earth") {
@@ -352,7 +349,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         guard let snapshot = renderPreparationPipeline.latestSnapshot,
               startFollowAnimation(named: name, snapshot: snapshot) else {
             pendingFollowPlanetName = name
-            cameraAnimationProgress = 1
+            cameraTransition = nil
             return
         }
 
@@ -365,7 +362,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         guard let snapshot = renderPreparationPipeline.latestSnapshot,
               applySelectedPlanet(named: name, snapshot: snapshot) else {
             pendingSelectedPlanetName = name
-            cameraAnimationProgress = 1
+            cameraTransition = nil
             return
         }
     }
@@ -437,11 +434,12 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             return
         }
 
-        startCameraTarget = cameraTarget
-        endCameraTarget = framing.center
-        startCameraDistance = cameraDistance
-        endCameraDistance = distanceToFitPlanet(radius: framing.radius) * 1.08
-        cameraAnimationProgress = 0
+        cameraTransition = CameraTransition(
+            start: currentCameraTransitionFrame,
+            destination: .fixed(target: framing.center,
+                                distance: distanceToFitPlanet(radius: framing.radius) * 1.08),
+            duration: cameraFollowTransitionDuration
+        )
     }
 
     private func earthCenteredTransferFraming(transferOrbit: HohmannTransferOrbit,
@@ -492,11 +490,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         }
 
         pendingFollowPlanetName = nil
-        cameraAnimationProgress = 1
-        startCameraTarget = nil
-        endCameraTarget = nil
-        startCameraDistance = nil
-        endCameraDistance = nil
+        cameraTransition = nil
     }
 
     func minimumAllowedCameraDistance(baseMinimum: Float) -> Float {
@@ -514,46 +508,65 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
     func startFollowAnimation(named name: String,
                               snapshot: PreparedRenderSnapshot) -> Bool {
-        var hasPreparedFollowData = false
-
-        if let position = snapshot.worldPosition(ofPlanetNamed: name) {
-            startCameraTarget = cameraTarget
-            endCameraTarget = position
-            hasPreparedFollowData = true
+        guard resolvedPlanetTransitionFrame(named: name,
+                                            snapshot: snapshot) != nil else {
+            return false
         }
 
-        if let framingRadius = snapshot.framingRadius(ofPlanetNamed: name) {
-            startCameraDistance = cameraDistance
-            endCameraDistance = distanceToFitPlanet(radius: framingRadius)
-            hasPreparedFollowData = true
-        }
-
-        guard hasPreparedFollowData else { return false }
-
-        cameraAnimationProgress = 0
+        cameraTransition = CameraTransition(
+            start: currentCameraTransitionFrame,
+            destination: .planet(name: name),
+            duration: cameraFollowTransitionDuration
+        )
         return true
     }
 
-    private func updateCameraAnimation(delta: Float) {
-        guard cameraAnimationProgress < 1,
-              let startTarget = startCameraTarget,
-              let endTarget = endCameraTarget,
-              let startDistance = startCameraDistance,
-              let endDistance = endCameraDistance else { return }
+    var currentCameraTransitionFrame: CameraTransition.Frame {
+        CameraTransition.Frame(target: cameraTarget,
+                               distance: cameraDistance)
+    }
 
-        cameraAnimationProgress = min(cameraAnimationProgress + delta / cameraAnimationDuration, 1)
-        let time = cameraAnimationProgress
-
-        cameraTarget = startTarget + (endTarget - startTarget) * time
-        cameraDistance = startDistance + (endDistance - startDistance) * time
-        updateCamera()
-
-        if cameraAnimationProgress >= 1 {
-            startCameraTarget = nil
-            endCameraTarget = nil
-            startCameraDistance = nil
-            endCameraDistance = nil
+    private func updateCameraTransition(snapshot: PreparedRenderSnapshot?,
+                                        delta: Float) {
+        guard var transition = cameraTransition else { return }
+        guard let frame = transition.advance(delta: delta, resolveDestination: { [weak self] destination in
+            guard let self else { return nil }
+            return self.resolveCameraTransitionDestination(destination,
+                                                           snapshot: snapshot)
+        }) else {
+            return
         }
+
+        cameraTransition = transition.isComplete ? nil : transition
+        cameraTarget = frame.target
+        cameraDistance = frame.distance
+        updateCamera()
+    }
+
+    private func resolveCameraTransitionDestination(_ destination: CameraTransition.Destination,
+                                                    snapshot: PreparedRenderSnapshot?)
+    -> CameraTransition.Frame? {
+        switch destination {
+        case .planet(let name):
+            guard let snapshot else { return nil }
+            return resolvedPlanetTransitionFrame(named: name,
+                                                 snapshot: snapshot)
+        case .fixed(let target, let distance):
+            return CameraTransition.Frame(target: target,
+                                          distance: distance)
+        }
+    }
+
+    private func resolvedPlanetTransitionFrame(named name: String,
+                                               snapshot: PreparedRenderSnapshot)
+    -> CameraTransition.Frame? {
+        guard let position = snapshot.worldPosition(ofPlanetNamed: name),
+              let framingRadius = snapshot.framingRadius(ofPlanetNamed: name) else {
+            return nil
+        }
+
+        return CameraTransition.Frame(target: position,
+                                      distance: distanceToFitPlanet(radius: framingRadius))
     }
 
     func updateCamera() {

--- a/Modules/MetalModule/Tests/MetalModuleTests/MetalModuleTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/MetalModuleTests.swift
@@ -41,6 +41,62 @@ private let testPlanets: [Planet] = [
            rotationSpeedKmSec: 0)
 ]
 
+@Test func cameraTransitionProgressClampsAtOne() throws {
+    var transition = CameraTransition(
+        start: CameraTransition.Frame(target: .zero, distance: 2),
+        destination: .fixed(target: SIMD3<Float>(10, 0, 0), distance: 8),
+        duration: 1
+    )
+
+    let frame = try #require(transition.advance(delta: 2) { destination in
+        guard case .fixed(let target, let distance) = destination else { return nil }
+        return CameraTransition.Frame(target: target, distance: distance)
+    })
+
+    #expect(transition.progress == 1)
+    #expect(transition.isComplete)
+    #expect(frame.target == SIMD3<Float>(10, 0, 0))
+    #expect(frame.distance == 8)
+}
+
+@Test func cameraTransitionCubicEaseStartsAndEndsExactly() throws {
+    let start = CameraTransition.Frame(target: SIMD3<Float>(1, 2, 3), distance: 4)
+    let end = CameraTransition.Frame(target: SIMD3<Float>(5, 6, 7), distance: 8)
+
+    #expect(CameraTransition.interpolate(from: start,
+                                         to: end,
+                                         progress: CameraTransition.easeInOutCubic(0)) == start)
+    #expect(CameraTransition.interpolate(from: start,
+                                         to: end,
+                                         progress: CameraTransition.easeInOutCubic(1)) == end)
+}
+
+@Test func cameraTransitionMidwayProgressIsSmoothAndMonotonic() {
+    let early = CameraTransition.easeInOutCubic(0.25)
+    let middle = CameraTransition.easeInOutCubic(0.5)
+    let late = CameraTransition.easeInOutCubic(0.75)
+
+    #expect(early > 0)
+    #expect(early < middle)
+    #expect(abs(middle - 0.5) < 0.0001)
+    #expect(middle < late)
+    #expect(late < 1)
+}
+
+@Test func cameraTransitionMissingDestinationDoesNotAdvance() {
+    var transition = CameraTransition(
+        start: CameraTransition.Frame(target: .zero, distance: 2),
+        destination: .planet(name: "Mars"),
+        duration: 1
+    )
+
+    let frame = transition.advance(delta: 0.5) { _ in nil }
+
+    #expect(frame == nil)
+    #expect(transition.progress == 0)
+    #expect(!transition.isComplete)
+}
+
 @Test func hohmannSemiMajorAxisUsesMeanOrbitRadius() {
     let transfer = HohmannTransferOrbit.make(destinationName: "Mars",
                                              planets: testPlanets,


### PR DESCRIPTION
## Summary
- Replaced the renderer’s ad hoc camera interpolation fields with a single `CameraTransition` state model.
- Added cubic ease-in-out camera motion for planet follow and transfer overview transitions so selected objects arrive with visible motion instead of snapping on screen.
- Kept gesture cancellation, navigation precedence, and existing SwiftUI selection flow intact.

Resolves #248

## Testing
- Added unit coverage for transition clamping, easing endpoints, monotonic mid-progress behavior, and missing-destination handling.
- Verified with Xcode builds and tests on the iPhone 17 Pro iOS 26.4 simulator destination.
- Confirmed the MetalModule test target passes through Xcode’s package test path.