### PR TITLE
Add GitHub Pages privacy policy and App Store privacy URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
       </a>
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="./support/">Support</a>
+        <a href="./privacy/">Privacy</a>
         <a href="https://github.com/llkenny/optiuniverse">GitHub</a>
       </nav>
     </header>
@@ -60,7 +61,7 @@
 
     <footer class="site-footer">
       <span>OptiUniverse Release 1</span>
-      <span><a href="./support/">Support</a> · <a href="https://github.com/llkenny/optiuniverse/issues">Report an issue</a></span>
+      <span><a href="./support/">Support</a> · <a href="./privacy/">Privacy</a> · <a href="https://github.com/llkenny/optiuniverse/issues">Report an issue</a></span>
     </footer>
   </body>
 </html>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OptiUniverse Privacy Policy</title>
+    <meta name="description" content="Privacy Policy for OptiUniverse Release 1 on iOS.">
+    <link rel="stylesheet" href="../styles.css">
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../" aria-label="OptiUniverse home">
+        <span class="brand-mark">OU</span>
+        <span>OptiUniverse</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="../">Marketing</a>
+        <a href="../support/">Support</a>
+        <a href="https://github.com/llkenny/optiuniverse">GitHub</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="section legal-content">
+        <p class="eyebrow">Privacy Policy</p>
+        <h1>OptiUniverse Privacy Policy</h1>
+        <p class="lead">Effective date: May 17, 2026</p>
+
+        <h2>Overview</h2>
+        <p>OptiUniverse is an iOS 3D solar-system viewer. For this App Store release, the app does not require an account, does not include advertising, does not use analytics SDKs, and does not track users across apps or websites.</p>
+
+        <h2>Information We Do Not Collect</h2>
+        <p>OptiUniverse does not collect or request:</p>
+        <ul>
+          <li>Names, email addresses, or account credentials.</li>
+          <li>Precise location, contacts, calendars, photos, camera, or microphone data.</li>
+          <li>Payment information or financial data.</li>
+          <li>Advertising identifiers or data used for third-party advertising.</li>
+        </ul>
+
+        <h2>Public Content Requests</h2>
+        <p>The app may request public destination and featured-object content from <code>api.kb404.com</code>. These requests are used to keep app content current and are not used for advertising or cross-app tracking.</p>
+        <p>Like most web services, the server may process standard technical request data such as IP address, request time, request path, and user agent for security, reliability, diagnostics, and operations.</p>
+
+        <h2>Third-Party Services</h2>
+        <p>OptiUniverse does not use third-party advertising or analytics SDKs in this release. This privacy policy is hosted with GitHub Pages, and GitHub may process standard web request data when you visit this page.</p>
+
+        <h2>Data Sharing</h2>
+        <p>We do not sell personal data. We do not share personal data with advertisers or data brokers. Technical request data may be handled by infrastructure providers only as needed to operate the app content service and this website.</p>
+
+        <h2>Children's Privacy</h2>
+        <p>OptiUniverse is a general-audience astronomy app and is not designed to collect personal information from children.</p>
+
+        <h2>Changes to This Policy</h2>
+        <p>If the app's data practices change in a future release, this policy will be updated and the new effective date will be shown here.</p>
+
+        <h2>Contact</h2>
+        <p>For privacy questions or requests, open an issue in the OptiUniverse GitHub issue tracker: <a href="https://github.com/llkenny/optiuniverse/issues/new">https://github.com/llkenny/optiuniverse/issues/new</a>.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <span>OptiUniverse Release 1</span>
+      <span><a href="../">Marketing</a> · <a href="../support/">Support</a> · <a href="https://github.com/llkenny/optiuniverse/issues/new">New issue</a></span>
+    </footer>
+  </body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -240,6 +240,33 @@ h3 {
   margin-top: 10px;
 }
 
+.legal-content {
+  max-width: 860px;
+}
+
+.legal-content h2 {
+  margin-top: 42px;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.legal-content p,
+.legal-content li {
+  color: var(--muted);
+}
+
+.legal-content p {
+  margin: 14px 0 0;
+}
+
+.legal-content ul {
+  margin: 18px 0 0;
+  padding-left: 1.2rem;
+}
+
+.legal-content li + li {
+  margin-top: 10px;
+}
+
 .site-footer {
   display: flex;
   justify-content: space-between;

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -15,6 +15,7 @@
       </a>
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../">Marketing</a>
+        <a href="../privacy/">Privacy</a>
         <a href="https://github.com/llkenny/optiuniverse">GitHub</a>
       </nav>
     </header>
@@ -56,7 +57,7 @@
 
     <footer class="site-footer">
       <span>OptiUniverse Release 1</span>
-      <span><a href="../">Marketing</a> · <a href="https://github.com/llkenny/optiuniverse/issues/new">New issue</a></span>
+      <span><a href="../">Marketing</a> · <a href="../privacy/">Privacy</a> · <a href="https://github.com/llkenny/optiuniverse/issues/new">New issue</a></span>
     </footer>
   </body>
 </html>

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://llkenny.github.io/optiuniverse/privacy/


### PR DESCRIPTION
## Summary
- Added a GitHub Pages privacy policy for the App Store release at `docs/privacy/index.html`.
- Linked the new privacy page from the main site and support pages.
- Added App Store metadata for the privacy policy URL in `fastlane/metadata/en-US/privacy_url.txt`.
- Reused the existing docs styling with a small legal-content layout for readable policy sections.

## Testing
- Verified the static docs site serves `/`, `/support/`, and `/privacy/` successfully.
- Checked the privacy page content, links, and policy disclosures locally in the browser.
- Confirmed the App Store privacy URL metadata matches the GitHub Pages target.