### PR TITLE
Move static content JSON to GitHub Pages

### DIFF
--- a/Modules/BaseModule/Sources/BaseModule/Services/Destinations/DestinationsProvider.swift
+++ b/Modules/BaseModule/Sources/BaseModule/Services/Destinations/DestinationsProvider.swift
@@ -12,7 +12,7 @@ actor DestinationsProvider: DestinationsProviderProtocol {
 
     enum Constants {
         static let filename = "DestinationObjects"
-        static let urlString = "https://api.kb404.com/static/DestinationObjects.json"
+        static let urlString = "https://llkenny.github.io/optiuniverse/static/DestinationObjects.json"
     }
 
     var destinations: [DestinationObject] = []

--- a/Modules/BaseModule/Sources/BaseModule/Services/FeaturedObjects/FeaturedObjectProvider.swift
+++ b/Modules/BaseModule/Sources/BaseModule/Services/FeaturedObjects/FeaturedObjectProvider.swift
@@ -12,7 +12,7 @@ actor FeaturedObjectProvider: FeaturedObjectProviderProtocol {
 
     enum Constants {
         static let filename = "FeaturedObjects"
-        static let urlString = "https://api.kb404.com/static/FeaturedObjects.json"
+        static let urlString = "https://llkenny.github.io/optiuniverse/static/FeaturedObjects.json"
     }
 
     var featuredObjects: [FeaturedObject] = []

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -39,14 +39,14 @@
         </ul>
 
         <h2>Public Content Requests</h2>
-        <p>The app may request public destination and featured-object content from <code>api.kb404.com</code>. These requests are used to keep app content current and are not used for advertising or cross-app tracking.</p>
+        <p>The app may request public destination and featured-object content from GitHub Pages at <code>llkenny.github.io/optiuniverse</code>. These requests are used to keep app content current and are not used for advertising or cross-app tracking.</p>
         <p>Like most web services, the server may process standard technical request data such as IP address, request time, request path, and user agent for security, reliability, diagnostics, and operations.</p>
 
         <h2>Third-Party Services</h2>
         <p>OptiUniverse does not use third-party advertising or analytics SDKs in this release. This privacy policy is hosted with GitHub Pages, and GitHub may process standard web request data when you visit this page.</p>
 
         <h2>Data Sharing</h2>
-        <p>We do not sell personal data. We do not share personal data with advertisers or data brokers. Technical request data may be handled by infrastructure providers only as needed to operate the app content service and this website.</p>
+        <p>We do not sell personal data. We do not share personal data with advertisers or data brokers. Technical request data may be handled by GitHub Pages only as needed to host app content and this website.</p>
 
         <h2>Children's Privacy</h2>
         <p>OptiUniverse is a general-audience astronomy app and is not designed to collect personal information from children.</p>

--- a/docs/static/DestinationObjects.json
+++ b/docs/static/DestinationObjects.json
@@ -1,0 +1,354 @@
+[
+    {
+        "id": "2A362A51-31E5-4609-8B0D-CE2FBC314F15",
+        "object": "Sun",
+        "title": "Sun",
+        "subtitle": "Solar Giant",
+        "description": "The Sun is the star at the center of the solar system, holding every planet in orbit with its gravity. Its roiling plasma, magnetic storms, and constant stream of solar wind shape conditions across interplanetary space.",
+        "imageName": "dst-Sun",
+        "tag": "🌶️ Hot",
+        "isNavigable": false,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "0",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "1.39M",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "230M",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "5,500",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "2F2B045C-4C7C-4797-A423-BAC3665F67AF",
+        "object": "Mercury",
+        "title": "Mercury",
+        "subtitle": "Swift Cratered World",
+        "description": "Mercury is the smallest planet and the closest world to the Sun. Its cratered surface, long solar days, and lack of a thick atmosphere create extreme swings between scorching daylight and freezing night.",
+        "imageName": "dst-Mercury",
+        "tag": "🌶️ Hot",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "0.39",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "4,879",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "88",
+                "dimension": "DAYS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-180 to 430",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "65759265-BD0F-43F8-BE5C-BD877D0EE4F6",
+        "object": "Venus",
+        "title": "Venus",
+        "subtitle": "Cloud Veiled Inferno",
+        "description": "Venus is wrapped in dense clouds of sulfuric acid above a crushing carbon dioxide atmosphere. Beneath that bright veil, runaway greenhouse heating makes its volcanic plains hotter than any other planet's surface.",
+        "imageName": "dst-Venus",
+        "tag": "🌶️ Hot",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "0.72",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "12,104",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "225",
+                "dimension": "DAYS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "465",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "C8D6C926-C315-45FC-8916-4A1457CEB94F",
+        "object": "Earth",
+        "title": "Earth",
+        "subtitle": "Blue Home World",
+        "description": "Earth is the only known world with stable surface oceans and a living biosphere. Its active geology, protective magnetic field, and layered atmosphere make it a dynamic oasis in the inner solar system.",
+        "imageName": "dst-Earth",
+        "tag": "🌎 Inhabited",
+        "isNavigable": false,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "1.00",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "12,742",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "365.25",
+                "dimension": "DAYS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "15",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "C8D6C926-C315-45FC-8916-4A1457CEB95F",
+        "object": "Moon",
+        "title": "Moon",
+        "subtitle": "Nearest Space Object",
+        "description": "The Moon is Earth's natural satellite and the nearest destination beyond our planet. Its ancient impact basins, airless plains, and steady presence in the sky preserve a record of early solar system history.",
+        "imageName": "dst-Moon",
+        "tag": "🪨 Satellite",
+        "isNavigable": false,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "384,400",
+                "dimension": "KM"
+            },
+            {
+                "title": "Diameter",
+                "value": "3,474",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "27.3",
+                "dimension": "DAYS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-173 to 127",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "2530E63D-699E-4F38-9B77-EABDE51152A5",
+        "object": "Mars",
+        "title": "Mars",
+        "subtitle": "Dust Storm Frontier",
+        "description": "Mars is a cold desert world marked by iron-rich dust, giant volcanoes, deep canyons, and dried river valleys. Its polar caps and buried ice make it one of the most compelling targets for future exploration.",
+        "imageName": "dst-Mars",
+        "tag": "🔥 Popular",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "1.52",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "6,779",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "687",
+                "dimension": "DAYS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-65",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "B09A3752-957D-4B27-AB40-C237B7CBEAD0",
+        "object": "Jupiter",
+        "title": "Jupiter",
+        "subtitle": "Great Storm Giant",
+        "description": "Jupiter is the largest planet, a fast-spinning gas giant with powerful bands, auroras, and storms larger than Earth. Its immense gravity shapes the outer solar system and shepherds a diverse family of moons.",
+        "imageName": "dst-Jupiter",
+        "tag": "🔥 Popular",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "5.20",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "139,820",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "11.86",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-110",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "9E86DC33-347C-48FD-8FB7-EC952E184418",
+        "object": "Saturn",
+        "title": "Saturn",
+        "subtitle": "Ring Crowned Giant",
+        "description": "Saturn is a pale gas giant encircled by the solar system's most spectacular ring system. The rings are made of countless icy fragments, while its moons range from hazy Titan to ocean-bearing Enceladus.",
+        "imageName": "dst-Saturn",
+        "tag": "🪐 Rings",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "9.58",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "116,460",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "29.45",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-140",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "BCE5A337-2F76-498F-BFC0-DEED598C933A",
+        "object": "Uranus",
+        "title": "Uranus",
+        "subtitle": "Tilted Ice Giant",
+        "description": "Uranus is an ice giant that rotates on its side, giving it seasons unlike any other planet. Its muted blue-green atmosphere, faint rings, and cold interior make it one of the solar system's strangest worlds.",
+        "imageName": "dst-Uranus",
+        "tag": "🪐 Rings",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "19.2",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "50,724",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "84",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-195",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "597DF2F3-98E7-4CFE-ACBA-C9D8B30F187E",
+        "object": "Neptune",
+        "title": "Neptune",
+        "subtitle": "Deep Blue Giant",
+        "description": "Neptune is the farthest major planet, a deep blue ice giant swept by supersonic winds. Dark storms, bright methane clouds, and the captured moon Triton give this distant world a restless, high-energy character.",
+        "imageName": "dst-Neptune",
+        "tag": "❄️ Cold",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "30.1",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "49,244",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "164.8",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-200",
+                "dimension": "C"
+            }
+        ]
+    },
+    {
+        "id": "16ED9A2A-BC78-4D2E-8B9C-E70C25C3F532",
+        "object": "Pluto",
+        "title": "Pluto",
+        "subtitle": "Distant Dwarf World",
+        "description": "Pluto is a small icy dwarf planet in the Kuiper Belt, marked by mountains, plains, craters, and frozen volatile ices. Its thin atmosphere and moon system make it one of the solar system's most intriguing distant worlds.",
+        "imageName": "dst-Pluto",
+        "tag": "❄️ Cold",
+        "isNavigable": true,
+        "details": [
+            {
+                "title": "Distance",
+                "value": "39",
+                "dimension": "AU"
+            },
+            {
+                "title": "Diameter",
+                "value": "2,377",
+                "dimension": "KM"
+            },
+            {
+                "title": "Orbital period",
+                "value": "248",
+                "dimension": "YEARS"
+            },
+            {
+                "title": "Surface temp",
+                "value": "-232",
+                "dimension": "C"
+            }
+        ]
+    }
+]

--- a/docs/static/FeaturedObjects.json
+++ b/docs/static/FeaturedObjects.json
@@ -1,0 +1,59 @@
+[
+    {
+        "id": "0E40ED4E-A635-41D3-974B-32C1FD2225DB",
+        "name": "Saturn",
+        "description": "Ringed giant",
+        "imageName": "Saturn_3",
+        "accentColor":
+        [
+            {
+                "red": 0.97,
+                "green": 0.72,
+                "blue": 0.42
+            },
+            {
+                "red": 0.34,
+                "green": 0.16,
+                "blue": 0.08
+            }
+        ]
+    },
+    {
+        "id": "83855A92-302D-46E5-87BC-A0DBA6748EF7",
+        "name": "Neptune",
+        "description": "Deep blue frontier",
+        "imageName": "Neptune_1",
+        "accentColor":
+        [
+            {
+                "red": 0.28,
+                "green": 0.57,
+                "blue": 0.98
+            },
+            {
+                "red": 0.04,
+                "green": 0.11,
+                "blue": 0.36
+            }
+        ]
+    },
+    {
+        "id": "E2232F82-868D-4F95-9BC8-CEFE50999A0E",
+        "name": "Mars",
+        "description": "Dust storms and canyons",
+        "imageName": "Mars_1",
+        "accentColor":
+        [
+            {
+                "red": 0.93,
+                "green": 0.45,
+                "blue": 0.28
+            },
+            {
+                "red": 0.29,
+                "green": 0.08,
+                "blue": 0.06
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Summary
- Added `docs/static/DestinationObjects.json` and `docs/static/FeaturedObjects.json` so the app’s public content can be hosted from GitHub Pages.
- Updated the destination and featured-object providers to fetch from `llkenny.github.io/optiuniverse` instead of `api.kb404.com`.
- Revised the privacy policy copy to reflect the new hosting location.

Resolves #283 

## Testing
- JSON syntax validation passed for both new static files.
- Verified the new Pages copies match the bundled resource JSON exactly.
- `xcodebuild ... build CODE_SIGNING_ALLOWED=NO` passed.
- `xcodebuild ... test CODE_SIGNING_ALLOWED=NO` passed.