### PR TITLE
Move follow camera behavior into the camera mode layer

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
@@ -4,26 +4,27 @@ import UIKit
 @MainActor
 final class CameraController: NSObject, UIGestureRecognizerDelegate {
 
-    weak var renderer: MetalRenderer?
     private let cameraCoordniator: CameraCoordinator
+    private let beginManualCameraControl: () -> Void
+    private let isTrajectoryModeActive: () -> Bool
 
     init(cameraCoordinator: CameraCoordinator,
-         renderer: MetalRenderer?) {
+         beginManualCameraControl: @escaping () -> Void,
+         isTrajectoryModeActive: @escaping () -> Bool) {
 
-        self.renderer = renderer
         cameraCoordniator = cameraCoordinator
+        self.beginManualCameraControl = beginManualCameraControl
+        self.isTrajectoryModeActive = isTrajectoryModeActive
         super.init()
     }
 
     func dismantle() {
-        cameraCoordniator.deactivate(renderer: renderer)
-        renderer = nil
+        cameraCoordniator.deactivate()
     }
 
     // MARK: - Gesture handling
     @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
-        guard let renderer = renderer else { return }
-        renderer.beginManualCameraControl()
+        beginManualCameraControl()
         let translation = gesture.translation(in: gesture.view)
         let velocity = gesture.velocity(in: gesture.view)
         cameraCoordniator.makeRotation(with: translation, velocity: velocity)
@@ -31,8 +32,7 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
     }
 
     @objc func handleTrajectoryPan(_ gesture: UIPanGestureRecognizer) {
-        guard let renderer = renderer else { return }
-        renderer.beginManualCameraControl()
+        beginManualCameraControl()
 
         let translation = gesture.translation(in: gesture.view)
         cameraCoordniator.makeTranslation(with: translation)
@@ -40,8 +40,7 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
     }
 
     @objc func handlePinch(_ gesture: UIPinchGestureRecognizer) {
-        guard let renderer = renderer else { return }
-        renderer.beginManualCameraControl()
+        beginManualCameraControl()
         let gestureScale = max(Float(gesture.scale), 0.01)
         cameraCoordniator.makeScale(with: gestureScale, velocity: gesture.velocity)
         gesture.scale = 1.0
@@ -57,6 +56,6 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
             return true
         }
 
-        return renderer?.isTrajectoryModeActive == true
+        return isTrajectoryModeActive()
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -11,23 +11,17 @@ import Foundation
 import QuartzCore
 import simd
 
-/*
- Owns camera mode priority, ownership, cancellation, and ticking.
- It decides which mode receives a command or time update,
- whether a command cancels or suspends another mode, and which transactional camera mutation is committed.
- Camera mode priority becomes explicit.
- Conflicts such as manual control cancelling follow, navigation owning the camera while active,
- or trajectory pan only applying in trajectory mode should be resolved by the camera mode layer or a camera coordinator,
- not by renderer branches.
-
- The coordinator must stay focused on routing and ownership.
- It should not perform matrix math or directly encode mode-specific camera behavior.
- Mode-specific transformations belong in the modes, and matrix derivation belongs in the snapshot provider.
-
- The implementation should avoid letting every mode freely mutate state in incompatible ways.
- Modes should emit camera commands or transactional mutations through `CameraCoordinator`
- so ownership and cancellation rules remain visible.
- */
+/// Routes camera commands to the active camera mode owners.
+///
+/// `CameraCoordinator` is the camera-layer entry point used by UI gestures, navigation, transfer
+/// preview, and the renderer frame loop. It owns mode priority and lifecycle routing, then delegates
+/// mode-specific math to owners/modes that commit `CameraState.Transaction` values.
+///
+/// ADR 0003 boundary:
+/// - UI and feature controllers call this coordinator instead of mutating renderer camera fields.
+/// - Follow, navigation, transfer preview, orbit, zoom, and trajectory behavior stay in camera modes.
+/// - `SnapshotProvider` derives render-ready matrices from committed `CameraState`; the coordinator
+///   only refreshes derived state needed by the current mode before snapshots are requested.
 @MainActor
 final class CameraCoordinator {
 
@@ -120,6 +114,10 @@ final class CameraCoordinator {
         followCameraOwner.beginManualCameraControl()
     }
 
+    /// Advances the follow camera when no higher-priority mode currently owns the camera.
+    ///
+    /// `isSuppressed` is true while navigation controls the camera or transfer preview is active.
+    /// Pending follow requests are preserved while suppressed and resolve on a later frame.
     func updateFollowCamera(snapshot: PreparedRenderSnapshot?,
                             delta: Float,
                             viewportSize: CGSize,
@@ -139,6 +137,10 @@ final class CameraCoordinator {
                                                baseProjection: baseProjection)
     }
 
+    /// Rebuilds derived camera values after mode transactions or gesture inertia.
+    ///
+    /// This replaces the old renderer-owned `updateCamera()` path while keeping matrix derivation
+    /// centralized in `CameraState`/`SnapshotProvider`.
     func refreshCamera(snapshot: PreparedRenderSnapshot? = nil) {
         let snapshot = snapshot ?? snapshotProvider.latestSnapshot
         cameraState.refreshDerivedCameraValues(

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreFoundation
+import CoreGraphics
 import Foundation
 import QuartzCore
 import simd
@@ -34,22 +35,26 @@ final class CameraCoordinator {
     private let orbitSpeed: Float = 0.01
 
     private let cameraState: CameraState
+    private unowned let snapshotProvider: SnapshotProvider
 
     private let zoomMode: ZoomCameraMode
     private let orbitMode: OrbitCameraMode
     private let trajectoryMode: TrajectoryCameraMode
+    let followCameraOwner: FollowCameraOwner
     let navigationCameraOwner: NavigationCameraOwner
     let transferPreviewCameraOwner: TransferPreviewCameraOwner
 
     private var displayLink: CADisplayLink?
 
-    weak var renderer: MetalRenderer?
-
-    init(cameraState: CameraState) {
+    init(cameraState: CameraState,
+         snapshotProvider: SnapshotProvider) {
         self.cameraState = cameraState
+        self.snapshotProvider = snapshotProvider
         zoomMode = .init(cameraState: cameraState)
         orbitMode = .init(cameraState: cameraState)
         trajectoryMode = .init(cameraState: cameraState)
+        followCameraOwner = .init(cameraState: cameraState,
+                                  snapshotProvider: snapshotProvider)
         navigationCameraOwner = .init(cameraState: cameraState)
         transferPreviewCameraOwner = .init(cameraState: cameraState)
     }
@@ -74,16 +79,12 @@ final class CameraCoordinator {
         cameraState.cameraDistance
     }
 
-    func activate(renderer: MetalRenderer) {
-        self.renderer = renderer
+    func activate() {
         startLoop()
     }
 
-    func deactivate(renderer: MetalRenderer?) {
-        if self.renderer === renderer || renderer == nil {
-            self.renderer = nil
-            stopLoop()
-        }
+    func deactivate() {
+        stopLoop()
     }
 
     func makeTranslation(with value: CGPoint) {
@@ -101,12 +102,56 @@ final class CameraCoordinator {
         zoomMode.addInertia(velocity: velocity)
     }
 
+    func followPlanet(named name: String,
+                      viewportSize: CGSize) {
+        followCameraOwner.followPlanet(named: name,
+                                       viewportSize: viewportSize)
+        refreshCamera()
+    }
+
+    func followNavigationDestination(named name: String,
+                                     viewportSize: CGSize) {
+        followCameraOwner.followPlanet(named: name,
+                                       viewportSize: viewportSize)
+        refreshCamera()
+    }
+
+    func beginManualCameraControl() {
+        followCameraOwner.beginManualCameraControl()
+    }
+
+    func updateFollowCamera(snapshot: PreparedRenderSnapshot?,
+                            delta: Float,
+                            viewportSize: CGSize,
+                            isSuppressed: Bool) {
+        followCameraOwner.update(snapshot: snapshot,
+                                 delta: delta,
+                                 viewportSize: viewportSize,
+                                 isSuppressed: isSuppressed)
+        if !isSuppressed {
+            refreshCamera(snapshot: snapshot)
+        }
+    }
+
+    func followProjectionParameters(snapshot: PreparedRenderSnapshot?,
+                                    baseProjection: CameraProjectionParameters) -> CameraProjectionParameters {
+        followCameraOwner.projectionParameters(snapshot: snapshot,
+                                               baseProjection: baseProjection)
+    }
+
+    func refreshCamera(snapshot: PreparedRenderSnapshot? = nil) {
+        let snapshot = snapshot ?? snapshotProvider.latestSnapshot
+        cameraState.refreshDerivedCameraValues(
+            minDistance: followCameraOwner.minimumAllowedCameraDistance(snapshot: snapshot)
+        )
+    }
+
     private func update(delta: Float) {
         zoomMode.update(delta: delta)
         orbitMode.update(delta: delta)
 
         if !isNavigationCameraActive {
-            renderer?.updateCamera()
+            refreshCamera()
         }
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraFit.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraFit.swift
@@ -5,10 +5,39 @@
 //  Created by max on 20.05.2026.
 //
 
+import CoreGraphics
+
 enum CameraFit {
     static let verticalFieldOfView: Float = .pi / 3
     static let viewportFill: Float = 0.84
     static let defaultNearPlane: Float = 0.1
     static let defaultFarPlane: Float = 10000
     static let minimumNearPlane: Float = 0.0005
+
+    static func distanceToFit(radius: Float,
+                              currentDistance: Float,
+                              viewportSize: CGSize) -> Float {
+        guard radius > 0 else { return max(currentDistance, defaultNearPlane) }
+
+        let width = max(Float(viewportSize.width), 1)
+        let height = max(Float(viewportSize.height), 1)
+        let aspect = width / height
+        let horizontalFieldOfView = 2 * atan(tan(verticalFieldOfView / 2) * aspect)
+        let limitingHalfFOV = min(verticalFieldOfView, horizontalFieldOfView) / 2
+        let targetHalfAngle = atan(viewportFill * tan(limitingHalfFOV))
+        let fittedDistance = radius / max(sin(targetHalfAngle), 0.001)
+
+        return max(fittedDistance, radius * 1.05)
+    }
+
+    static func nearPlaneDistance(cameraDistance: Float,
+                                  framingRadius: Float?) -> Float {
+        guard let framingRadius else {
+            return defaultNearPlane
+        }
+
+        let frontClearance = max(cameraDistance - framingRadius, minimumNearPlane * 2)
+        return min(defaultNearPlane,
+                   max(minimumNearPlane, frontClearance * 0.5))
+    }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
@@ -147,6 +147,12 @@ final class CameraState {
         set(cameraDistance: fixedDinstance)
     }
 
+    @discardableResult
+    func refreshDerivedCameraValues(minDistance: Float) -> float4x4 {
+        checkDistance(minDistance: minDistance)
+        return makeViewMatrix()
+    }
+
     func makeRenderViewMatrix() -> float4x4 {
         float4x4.lookAt(
             eye: cameraOffset,

--- a/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
@@ -7,6 +7,19 @@
 
 import CoreGraphics
 
+/// Owns lifecycle state for the current planet-follow camera mode.
+///
+/// `FollowCameraOwner` is the stateful companion to `FollowCameraMode`. It retains the current
+/// followed planet, retries follow requests that arrive before a prepared snapshot is available,
+/// and advances follow transitions over render frames.
+///
+/// Ownership rules:
+/// - user follow commands are routed here by `MetalModuleResources` after clearing/cancelling
+///   higher-level modes such as transfer preview and route navigation
+/// - navigation/transfer fallback handoffs can reuse the same follow path without recursively
+///   cancelling navigation
+/// - manual control clears pending/active follow transitions, but keeps the selected follow target
+///   so steady follow can resume when the camera is not suppressed
 @MainActor
 final class FollowCameraOwner {
     private unowned let cameraState: CameraState
@@ -46,6 +59,10 @@ final class FollowCameraOwner {
         cameraTransition = nil
     }
 
+    /// Advances pending follow resolution, active transitions, or steady target tracking.
+    ///
+    /// Suppression is used while navigation or transfer preview owns the camera. In that state, the
+    /// owner keeps follow intent but avoids committing camera transactions.
     func update(snapshot: PreparedRenderSnapshot?,
                 delta: Float,
                 viewportSize: CGSize,

--- a/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
@@ -1,0 +1,143 @@
+//
+//  FollowCameraOwner.swift
+//  MetalModule
+//
+//  Created by Codex on 29.05.2026.
+//
+
+import CoreGraphics
+
+@MainActor
+final class FollowCameraOwner {
+    private unowned let cameraState: CameraState
+    private unowned let snapshotProvider: SnapshotProvider
+    private let followMode: FollowCameraMode
+
+    private(set) var followingPlanetName: String? = "Sun"
+    private var pendingFollowPlanetName: String?
+    private var cameraTransition: CameraTransition?
+
+    init(cameraState: CameraState,
+         snapshotProvider: SnapshotProvider,
+         followMode: FollowCameraMode = FollowCameraMode()) {
+        self.cameraState = cameraState
+        self.snapshotProvider = snapshotProvider
+        self.followMode = followMode
+    }
+
+    func followPlanet(named name: String,
+                      viewportSize: CGSize) {
+        followingPlanetName = name
+
+        guard let snapshot = snapshotProvider.latestSnapshot,
+              startFollowAnimation(named: name,
+                                   snapshot: snapshot,
+                                   viewportSize: viewportSize) else {
+            pendingFollowPlanetName = name
+            cameraTransition = nil
+            return
+        }
+
+        pendingFollowPlanetName = nil
+    }
+
+    func beginManualCameraControl() {
+        pendingFollowPlanetName = nil
+        cameraTransition = nil
+    }
+
+    func update(snapshot: PreparedRenderSnapshot?,
+                delta: Float,
+                viewportSize: CGSize,
+                isSuppressed: Bool) {
+        guard let snapshot else { return }
+
+        if !isSuppressed,
+           let name = pendingFollowPlanetName,
+           startFollowAnimation(named: name,
+                                snapshot: snapshot,
+                                viewportSize: viewportSize) {
+            pendingFollowPlanetName = nil
+        }
+
+        guard !isSuppressed else { return }
+
+        if cameraTransition != nil {
+            updateCameraTransition(snapshot: snapshot,
+                                   delta: delta,
+                                   viewportSize: viewportSize)
+        } else if let name = followingPlanetName,
+                  let transaction = followMode.makeSteadyFollowTransaction(named: name,
+                                                                           snapshot: snapshot) {
+            cameraState.commit(transaction)
+        }
+    }
+
+    func minimumAllowedCameraDistance(snapshot: PreparedRenderSnapshot?) -> Float {
+        followMode.minimumDistance(followingPlanetName: followingPlanetName,
+                                   snapshot: snapshot,
+                                   baseMinimumDistance: cameraState.minDistance)
+    }
+
+    func projectionParameters(snapshot: PreparedRenderSnapshot?,
+                              baseProjection: CameraProjectionParameters) -> CameraProjectionParameters {
+        followMode.projectionParameters(followingPlanetName: followingPlanetName,
+                                        snapshot: snapshot,
+                                        cameraDistance: cameraState.cameraDistance,
+                                        baseProjection: baseProjection)
+    }
+
+    private func startFollowAnimation(named name: String,
+                                      snapshot: PreparedRenderSnapshot,
+                                      viewportSize: CGSize) -> Bool {
+        guard followMode.makeTransitionFrame(named: name,
+                                             snapshot: snapshot,
+                                             currentDistance: cameraState.cameraDistance,
+                                             viewportSize: viewportSize) != nil else {
+            return false
+        }
+
+        cameraTransition = CameraTransition(
+            start: cameraState.currentCameraTransitionFrame,
+            destination: .planet(name: name),
+            duration: cameraState.cameraFollowTransitionDuration
+        )
+        return true
+    }
+
+    private func updateCameraTransition(snapshot: PreparedRenderSnapshot,
+                                        delta: Float,
+                                        viewportSize: CGSize) {
+        guard var transition = cameraTransition else { return }
+        guard let frame = transition.advance(delta: delta, resolveDestination: { [weak self] destination in
+            guard let self else { return nil }
+            return self.resolveCameraTransitionDestination(destination,
+                                                           snapshot: snapshot,
+                                                           viewportSize: viewportSize)
+        }) else {
+            return
+        }
+
+        cameraTransition = transition.isComplete ? nil : transition
+        cameraState.commit(followMode.makeTransitionTransaction(
+            frame: frame,
+            cameraOrientation: cameraState.cameraOrientation
+        ))
+    }
+
+    private func resolveCameraTransitionDestination(_ destination: CameraTransition.Destination,
+                                                    snapshot: PreparedRenderSnapshot,
+                                                    viewportSize: CGSize)
+    -> CameraTransition.Frame? {
+        switch destination {
+        case .planet(let name):
+            return followMode.makeTransitionFrame(named: name,
+                                                  snapshot: snapshot,
+                                                  currentDistance: cameraState.cameraDistance,
+                                                  viewportSize: viewportSize)
+        case .fixed(let target, let distance):
+            return CameraTransition.Frame(target: target,
+                                          distance: distance)
+        }
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
@@ -8,8 +8,18 @@
 import CoreGraphics
 import simd
 
-/// Computes camera transactions for the current planet-follow behavior.
+/// Computes transactions for the current planet-follow camera mode.
+///
+/// This type is intentionally stateless. `FollowCameraOwner` stores the selected planet, pending
+/// requests, and transition lifecycle; `FollowCameraMode` only translates a prepared scene snapshot,
+/// viewport, and current camera values into transaction-ready camera data.
+///
+/// The mode preserves the existing follow behavior:
+/// - smoothly transition to a selected planet using its framing radius
+/// - keep the camera target locked to the followed planet as simulation time advances
+/// - tighten minimum distance and near plane around the followed planet
 final class FollowCameraMode {
+    /// Returns the per-frame target update for a followed planet.
     func makeSteadyFollowTransaction(named name: String,
                                      snapshot: PreparedRenderSnapshot) -> CameraState.Transaction? {
         guard let position = snapshot.worldPosition(ofPlanetNamed: name) else {
@@ -19,6 +29,7 @@ final class FollowCameraMode {
         return CameraState.Transaction(cameraTarget: position)
     }
 
+    /// Resolves a transition destination for a planet follow animation.
     func makeTransitionFrame(named name: String,
                              snapshot: PreparedRenderSnapshot,
                              currentDistance: Float,
@@ -36,6 +47,7 @@ final class FollowCameraMode {
         )
     }
 
+    /// Converts an eased transition frame into canonical camera variables.
     func makeTransitionTransaction(frame: CameraTransition.Frame,
                                    cameraOrientation: simd_quatf) -> CameraState.Transaction {
         let orientation = simd_normalize(cameraOrientation)
@@ -51,6 +63,7 @@ final class FollowCameraMode {
                                        cameraOrientation: orientation)
     }
 
+    /// Keeps zoom outside the followed planet's visual radius.
     func minimumDistance(followingPlanetName: String?,
                          snapshot: PreparedRenderSnapshot?,
                          baseMinimumDistance: Float) -> Float {
@@ -62,6 +75,7 @@ final class FollowCameraMode {
         return max(baseMinimumDistance, framingRadius * 1.05)
     }
 
+    /// Applies follow-specific near-plane policy while preserving the caller's far plane.
     func projectionParameters(followingPlanetName: String?,
                               snapshot: PreparedRenderSnapshot?,
                               cameraDistance: Float,

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
@@ -1,0 +1,80 @@
+//
+//  FollowCameraMode.swift
+//  MetalModule
+//
+//  Created by Codex on 29.05.2026.
+//
+
+import CoreGraphics
+import simd
+
+/// Computes camera transactions for the current planet-follow behavior.
+final class FollowCameraMode {
+    func makeSteadyFollowTransaction(named name: String,
+                                     snapshot: PreparedRenderSnapshot) -> CameraState.Transaction? {
+        guard let position = snapshot.worldPosition(ofPlanetNamed: name) else {
+            return nil
+        }
+
+        return CameraState.Transaction(cameraTarget: position)
+    }
+
+    func makeTransitionFrame(named name: String,
+                             snapshot: PreparedRenderSnapshot,
+                             currentDistance: Float,
+                             viewportSize: CGSize) -> CameraTransition.Frame? {
+        guard let position = snapshot.worldPosition(ofPlanetNamed: name),
+              let framingRadius = snapshot.framingRadius(ofPlanetNamed: name) else {
+            return nil
+        }
+
+        return CameraTransition.Frame(
+            target: position,
+            distance: CameraFit.distanceToFit(radius: framingRadius,
+                                              currentDistance: currentDistance,
+                                              viewportSize: viewportSize)
+        )
+    }
+
+    func makeTransitionTransaction(frame: CameraTransition.Frame,
+                                   cameraOrientation: simd_quatf) -> CameraState.Transaction {
+        let orientation = simd_normalize(cameraOrientation)
+        let cameraOffset = orientation.act(SIMD3<Float>(0, 0, frame.distance))
+        let cameraPosition = cameraOffset + frame.target
+        let cameraUp = orientation.act(SIMD3<Float>(0, 1, 0))
+
+        return CameraState.Transaction(cameraTarget: frame.target,
+                                       cameraPosition: cameraPosition,
+                                       cameraDistance: frame.distance,
+                                       cameraUp: cameraUp,
+                                       cameraOffset: cameraOffset,
+                                       cameraOrientation: orientation)
+    }
+
+    func minimumDistance(followingPlanetName: String?,
+                         snapshot: PreparedRenderSnapshot?,
+                         baseMinimumDistance: Float) -> Float {
+        guard let followingPlanetName,
+              let framingRadius = snapshot?.framingRadius(ofPlanetNamed: followingPlanetName) else {
+            return baseMinimumDistance
+        }
+
+        return max(baseMinimumDistance, framingRadius * 1.05)
+    }
+
+    func projectionParameters(followingPlanetName: String?,
+                              snapshot: PreparedRenderSnapshot?,
+                              cameraDistance: Float,
+                              baseProjection: CameraProjectionParameters) -> CameraProjectionParameters {
+        guard let followingPlanetName else {
+            return baseProjection
+        }
+
+        let framingRadius = snapshot?.framingRadius(ofPlanetNamed: followingPlanetName)
+        return CameraProjectionParameters(
+            nearPlane: CameraFit.nearPlaneDistance(cameraDistance: cameraDistance,
+                                                   framingRadius: framingRadius),
+            farPlane: baseProjection.farPlane
+        )
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources.swift
@@ -31,9 +31,10 @@ public final class MetalModuleResources {
         renderPreparationPipeline = RenderPreparationPipeline(modelLoader: meshProvider.modelLoader,
                                                               planets: planets)
         cameraState = CameraState()
-        cameraCoordinator = CameraCoordinator(cameraState: cameraState)
         snapshotProvider = SnapshotProvider(cameraState: cameraState,
                                             snapshotSource: renderPreparationPipeline)
+        cameraCoordinator = CameraCoordinator(cameraState: cameraState,
+                                              snapshotProvider: snapshotProvider)
         transferOrbitController = TransferOrbitController(
             snapshotProvider: snapshotProvider,
             cameraCoordinator: cameraCoordinator,
@@ -70,7 +71,7 @@ public final class MetalModuleResources {
         guard let renderer = MetalRenderer(metalView: metalView,
                                            device: meshProvider.device,
                                            commandQueue: commandQueue,
-                                           cameraState: cameraState,
+                                           cameraCoordinator: cameraCoordinator,
                                            planets: planets,
                                            snapshotProvider: snapshotProvider,
                                            navigationController: navigationController,
@@ -78,13 +79,35 @@ public final class MetalModuleResources {
             return nil
         }
         self.renderer = renderer
-        navigationController.followPlanet = { [weak renderer] name in
-            renderer?.followNavigationDestination(named: name)
+        navigationController.followPlanet = { [weak self, weak renderer] name in
+            guard let self else { return }
+            self.cameraCoordinator.followNavigationDestination(named: name,
+                                                               viewportSize: renderer?.metalView.bounds.size ?? .zero)
         }
-        transferOrbitController.followPlanet = { [weak renderer] name in
-            renderer?.followNavigationDestination(named: name)
+        transferOrbitController.followPlanet = { [weak self, weak renderer] name in
+            guard let self else { return }
+            self.cameraCoordinator.followNavigationDestination(named: name,
+                                                               viewportSize: renderer?.metalView.bounds.size ?? .zero)
         }
-        cameraCoordinator.activate(renderer: renderer)
+        cameraCoordinator.activate()
         return renderer
+    }
+
+    var isTrajectoryModeActive: Bool {
+        transferOrbitController.isTransferPreviewActive ||
+        navigationController.isNavigationActive
+    }
+
+    func followPlanet(named name: String) {
+        transferOrbitController.clearTransferOrbit()
+        navigationController.cancelNavigation(followDestination: false)
+        cameraCoordinator.followPlanet(named: name,
+                                       viewportSize: renderer?.metalView.bounds.size ?? .zero)
+    }
+
+    func beginManualCameraControl() {
+        navigationController.beginManualCameraControl()
+        transferOrbitController.beginManualCameraControl()
+        cameraCoordinator.beginManualCameraControl()
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController+Projection.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController+Projection.swift
@@ -18,10 +18,8 @@ extension NavigationController {
         if navigationRouteCoordinator.isNavigationActive,
            navigationCameraFollowEnabled,
            let framingRadius = snapshot?.framingRadius(ofPlanetNamed: route.destinationName) {
-            let frontClearance = max(cameraCoordinator.cameraDistance - framingRadius,
-                                     CameraFit.minimumNearPlane * 2)
-            nearPlane = min(CameraFit.defaultNearPlane,
-                            max(CameraFit.minimumNearPlane, frontClearance * 0.5))
+            nearPlane = CameraFit.nearPlaneDistance(cameraDistance: cameraCoordinator.cameraDistance,
+                                                    framingRadius: framingRadius)
         }
 
         var farPlane = baseProjection.farPlane
@@ -109,17 +107,8 @@ extension NavigationController {
     }
 
     func distanceToFitPlanet(radius: Float) -> Float {
-        guard radius > 0 else { return max(cameraCoordinator.cameraDistance, CameraFit.defaultNearPlane) }
-
-        let size = viewportSize()
-        let width = max(Float(size.width), 1)
-        let height = max(Float(size.height), 1)
-        let aspect = width / height
-        let horizontalFieldOfView = 2 * atan(tan(CameraFit.verticalFieldOfView / 2) * aspect)
-        let limitingHalfFOV = min(CameraFit.verticalFieldOfView, horizontalFieldOfView) / 2
-        let targetHalfAngle = atan(CameraFit.viewportFill * tan(limitingHalfFOV))
-        let fittedDistance = radius / max(sin(targetHalfAngle), 0.001)
-
-        return max(fittedDistance, radius * 1.05)
+        CameraFit.distanceToFit(radius: radius,
+                                currentDistance: cameraCoordinator.cameraDistance,
+                                viewportSize: viewportSize())
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
@@ -246,17 +246,8 @@ final class TransferOrbitController {
     }
 
     private func distanceToFitPlanet(radius: Float) -> Float {
-        guard radius > 0 else { return max(cameraCoordinator.cameraDistance, CameraFit.defaultNearPlane) }
-
-        let size = viewportSize()
-        let width = max(Float(size.width), 1)
-        let height = max(Float(size.height), 1)
-        let aspect = width / height
-        let horizontalFieldOfView = 2 * atan(tan(CameraFit.verticalFieldOfView / 2) * aspect)
-        let limitingHalfFOV = min(CameraFit.verticalFieldOfView, horizontalFieldOfView) / 2
-        let targetHalfAngle = atan(CameraFit.viewportFill * tan(limitingHalfFOV))
-        let fittedDistance = radius / max(sin(targetHalfAngle), 0.001)
-
-        return max(fittedDistance, radius * 1.05)
+        CameraFit.distanceToFit(radius: radius,
+                                currentDistance: cameraCoordinator.cameraDistance,
+                                viewportSize: viewportSize())
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/RendererCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/RendererCoordinator.swift
@@ -10,6 +10,7 @@ import UIKit
 @MainActor
 public final class RendererCoordinator: NSObject, PlanetLabelDelegate {
     var renderer: MetalRenderer?
+    weak var resources: MetalModuleResources?
     private var labels: [String: UILabel] = [:]
     var currentSelectedPlanet: String?
     var cameraController: CameraController?
@@ -54,6 +55,6 @@ public final class RendererCoordinator: NSObject, PlanetLabelDelegate {
     @objc func handleLabelTap(_ gesture: UITapGestureRecognizer) {
         guard let label = gesture.view as? UILabel,
               let name = label.text else { return }
-        renderer?.followPlanet(named: name)
+        resources?.followPlanet(named: name)
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import MetalKit
-import os
 import QuartzCore
 import simd
 
@@ -17,26 +16,12 @@ protocol PlanetLabelDelegate: AnyObject {
     func updatePlanetLabels(_ positions: [String: SIMD2<Float>])
 }
 
-// swiftlint:disable type_body_length file_length
 @MainActor
 final class MetalRenderer: NSObject, MTKViewDelegate {
     enum PostFXStyle: UInt32 {
         case standard = 0
         case dreamy = 1
     }
-
-    private let projectionMatrixLogger = MatrixChangeLogger(
-        logger: Logger(subsystem: "com.OptiUniverse.MetalRenderer",
-                       category: "projectionMatrix"),
-        caption: "Projection Matrix update:",
-        queueLabel: "com.OptiUniverse.MetalRenderer.projectionMatrixLogging"
-    )
-    private let viewMatrixLogger = MatrixChangeLogger(
-        logger: Logger(subsystem: "com.OptiUniverse.MetalRenderer",
-                       category: "viewMatrix"),
-        caption: "View Matrix update:",
-        queueLabel: "com.OptiUniverse.MetalRenderer.viewMatrixLogging"
-    )
 
     private let device: MTLDevice
     let commandQueue: MTLCommandQueue
@@ -68,40 +53,21 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                     saturationBoost: 1.08)
     var cartoonShaderIntensity: Float = 0
 
-    private(set) unowned var cameraState: CameraState // The renderer must not exists without the camera state
-
-    var followingPlanetName: String? = "Sun"
-    var pendingFollowPlanetName: String?
-    var cameraTransition: CameraTransition?
+    let cameraCoordinator: CameraCoordinator
 
     let planets: [Planet]
-
-    var viewMatrix: float4x4 {
-        didSet {
-            viewMatrixLogger.logChange(from: oldValue, to: viewMatrix)
-        }
-    }
-    private(set) var projectionMatrix: float4x4 {
-        didSet {
-            projectionMatrixLogger.logChange(from: oldValue, to: projectionMatrix)
-        }
-    }
-    var isTrajectoryModeActive: Bool {
-        transferOrbitController.isTransferPreviewActive ||
-        navigationController.isNavigationActive
-    }
 
     init?(metalView: MTKView,
           device: MTLDevice,
           commandQueue: MTLCommandQueue,
-          cameraState: CameraState,
+          cameraCoordinator: CameraCoordinator,
           planets: [Planet],
           snapshotProvider: SnapshotProvider,
           navigationController: NavigationController,
           transferOrbitController: TransferOrbitController) {
 
         self.metalView = metalView
-        self.cameraState = cameraState
+        self.cameraCoordinator = cameraCoordinator
         self.snapshotProvider = snapshotProvider
         self.navigationController = navigationController
         self.transferOrbitController = transferOrbitController
@@ -122,15 +88,8 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         transferOrbitRenderer = TransferOrbitRenderer(device: device, sampleCount: viewSampleCount)
         routeRenderer = RouteRenderer(device: device, sampleCount: viewSampleCount)
 
-        viewMatrix = matrix_identity_float4x4
-        projectionMatrix = matrix_identity_float4x4
-
         super.init()
         prepare(viewSampleCount: viewSampleCount)
-    }
-
-    func setup(_ cameraState: CameraState) {
-        self.cameraState = cameraState
     }
 
     func dismantle() {
@@ -167,7 +126,6 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
 
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         // Handle view size changes
-        updateCamera()
         guard size.width > 0 && size.height > 0 else {
             hdrTexture = nil
             msaaColorTexture = nil
@@ -207,24 +165,26 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         snapshotProvider.requestPreparation(simulationTime: planetsRenderer.currentTime)
         let snapshot = snapshotProvider.latestSnapshot
 
-        update(snapshot: snapshot)
         transferOrbitController.update(snapshot: snapshot,
                                        delta: delta)
         navigationController.update(snapshot: snapshot,
                                     delta: delta)
-        if !navigationController.controlsCamera {
-            updateCamera(snapshot: snapshot,
-                         delta: delta)
-        }
-        let baseProjection = CameraProjectionParameters(nearPlane: nearPlaneDistance(),
+        let suppressFollowCamera = navigationController.controlsCamera ||
+        transferOrbitController.isTransferPreviewActive
+        cameraCoordinator.updateFollowCamera(snapshot: snapshot,
+                                             delta: delta,
+                                             viewportSize: metalView.bounds.size,
+                                             isSuppressed: suppressFollowCamera)
+        let baseProjection = CameraProjectionParameters(nearPlane: CameraFit.defaultNearPlane,
                                                         farPlane: farPlaneDistance())
+        let followProjection = cameraCoordinator.followProjectionParameters(snapshot: snapshot,
+                                                                            baseProjection: baseProjection)
         let transferProjection = transferOrbitController.projectionParameters(snapshot: snapshot,
-                                                                             baseProjection: baseProjection)
+                                                                             baseProjection: followProjection)
         let projection = navigationController.projectionParameters(snapshot: snapshot,
                                                                   baseProjection: transferProjection)
         let cameraSnapshot = snapshotProvider.makeCameraSnapshot(viewportSize: metalView.bounds.size,
                                                                  projection: projection)
-        projectionMatrix = cameraSnapshot.projectionMatrix
 
         do {
             try drawFirstPass(msaaColorTexture: msaaColorTexture,
@@ -244,183 +204,6 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         } catch {
             // Just skip — possible due transient Metal resource failures
         }
-    }
-
-    private func update(snapshot: PreparedRenderSnapshot?) {
-        guard let snapshot else { return }
-
-        if let name = pendingFollowPlanetName,
-           startFollowAnimation(named: name, snapshot: snapshot) {
-            pendingFollowPlanetName = nil
-        }
-    }
-
-    private func updateCamera(snapshot: PreparedRenderSnapshot?,
-                              delta: Float) {
-        if cameraTransition != nil {
-            updateCameraTransition(snapshot: snapshot,
-                                   delta: delta)
-        } else if transferOrbitController.isTransferPreviewActive {
-            return
-        } else if let name = followingPlanetName, // 5
-                  let position = snapshot?.worldPosition(ofPlanetNamed: name) {
-            cameraState.set(cameraTarget: position)
-            updateCamera()
-        }
-    }
-
-    func updateProjectionMatrix() {
-        let aspect = Float(metalView.bounds.width / metalView.bounds.height)
-        projectionMatrix = float4x4.perspective(
-            fov: CameraFit.verticalFieldOfView,
-            aspect: aspect,
-            near: nearPlaneDistance(),
-            far: farPlaneDistance()
-        )
-    }
-
-    /// Starts following the planet with the given name.
-    /// The camera moves smoothly to the planet's position and adjusts
-    /// distance based on the planet's radius.
-    func followPlanet(named name: String) {
-        followPlanet(named: name,
-                     cancelsNavigation: true)
-    }
-
-    func followNavigationDestination(named name: String) {
-        followPlanet(named: name,
-                     cancelsNavigation: false)
-    }
-
-    private func followPlanet(named name: String,
-                              cancelsNavigation: Bool) {
-        transferOrbitController.clearTransferOrbit()
-        if cancelsNavigation {
-            navigationController.cancelNavigation(followDestination: false)
-        }
-        followingPlanetName = name
-
-        guard let snapshot = snapshotProvider.latestSnapshot,
-              startFollowAnimation(named: name, snapshot: snapshot) else {
-            pendingFollowPlanetName = name
-            cameraTransition = nil
-            return
-        }
-
-        pendingFollowPlanetName = nil
-    }
-
-    /// Stops any active camera interpolation so direct gestures manipulate
-    /// distance/orbit immediately without being overridden on the next frame.
-    func beginManualCameraControl() {
-        navigationController.beginManualCameraControl()
-        transferOrbitController.beginManualCameraControl()
-        pendingFollowPlanetName = nil
-        cameraTransition = nil
-    }
-
-    func startFollowAnimation(named name: String,
-                              snapshot: PreparedRenderSnapshot) -> Bool {
-        guard resolvedPlanetTransitionFrame(named: name,
-                                            snapshot: snapshot) != nil else {
-            return false
-        }
-
-        cameraTransition = CameraTransition(
-            start: cameraState.currentCameraTransitionFrame,
-            destination: .planet(name: name),
-            duration: cameraState.cameraFollowTransitionDuration
-        )
-        return true
-    }
-
-    private func updateCameraTransition(snapshot: PreparedRenderSnapshot?,
-                                        delta: Float) {
-        guard var transition = cameraTransition else { return }
-        guard let frame = transition.advance(delta: delta, resolveDestination: { [weak self] destination in
-            guard let self else { return nil }
-            return self.resolveCameraTransitionDestination(destination,
-                                                           snapshot: snapshot)
-        }) else {
-            return
-        }
-
-        cameraTransition = transition.isComplete ? nil : transition
-        cameraState.set(cameraTarget: frame.target)
-        cameraState.set(cameraDistance: frame.distance)
-        updateCamera()
-    }
-
-    private func resolveCameraTransitionDestination(_ destination: CameraTransition.Destination,
-                                                    snapshot: PreparedRenderSnapshot?)
-    -> CameraTransition.Frame? {
-        switch destination {
-        case .planet(let name):
-            guard let snapshot else { return nil }
-            return resolvedPlanetTransitionFrame(named: name,
-                                                 snapshot: snapshot)
-        case .fixed(let target, let distance):
-            return CameraTransition.Frame(target: target,
-                                          distance: distance)
-        }
-    }
-
-    private func resolvedPlanetTransitionFrame(named name: String,
-                                               snapshot: PreparedRenderSnapshot)
-    -> CameraTransition.Frame? {
-        guard let position = snapshot.worldPosition(ofPlanetNamed: name),
-              let framingRadius = snapshot.framingRadius(ofPlanetNamed: name) else {
-            return nil
-        }
-
-        return CameraTransition.Frame(target: position,
-                                      distance: distanceToFitPlanet(radius: framingRadius))
-    }
-
-    func updateCamera() {
-        cameraState.checkDistance(minDistance: minimumAllowedCameraDistance())
-        viewMatrix = cameraState.makeViewMatrix()
-        updateProjectionMatrix()
-    }
-
-    private func minimumAllowedCameraDistance() -> Float {
-        let minDistance = cameraState.minDistance
-
-        guard let followingPlanetName,
-              let framingRadius = snapshotProvider
-            .latestSnapshot?
-            .framingRadius(ofPlanetNamed: followingPlanetName) else {
-            return minDistance
-        }
-
-        return max(minDistance, framingRadius * 1.05)
-    }
-
-    func distanceToFitPlanet(radius: Float) -> Float {
-        guard radius > 0 else { return max(cameraState.cameraDistance, CameraFit.defaultNearPlane) }
-
-        let width = max(Float(metalView.bounds.width), 1)
-        let height = max(Float(metalView.bounds.height), 1)
-        let aspect = width / height
-        let horizontalFieldOfView = 2 * atan(tan(CameraFit.verticalFieldOfView / 2) * aspect)
-        let limitingHalfFOV = min(CameraFit.verticalFieldOfView, horizontalFieldOfView) / 2
-        let targetHalfAngle = atan(CameraFit.viewportFill * tan(limitingHalfFOV))
-        let fittedDistance = radius / max(sin(targetHalfAngle), 0.001)
-
-        return max(fittedDistance, radius * 1.05)
-    }
-
-    private func nearPlaneDistance() -> Float {
-        guard let followingPlanetName,
-              let framingRadius = snapshotProvider
-            .latestSnapshot?
-            .framingRadius(ofPlanetNamed: followingPlanetName) else {
-            return CameraFit.defaultNearPlane
-        }
-
-        let frontClearance = max(cameraState.cameraDistance - framingRadius, CameraFit.minimumNearPlane * 2)
-        return min(CameraFit.defaultNearPlane,
-                   max(CameraFit.minimumNearPlane, frontClearance * 0.5))
     }
 
     private func farPlaneDistance() -> Float {
@@ -503,4 +286,3 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         return device.makeTexture(descriptor: descriptor)!
     }
 }
-// swiftlint:enable type_body_length

--- a/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
+++ b/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
@@ -41,10 +41,16 @@ public struct UniverseView: UIViewRepresentable {
 
         let renderer = resources.makeRenderer(for: mtkView)
         context.coordinator.renderer = renderer
+        context.coordinator.resources = resources
         renderer?.labelDelegate = context.coordinator
 
         let cameraController = CameraController(cameraCoordinator: resources.cameraCoordinator,
-                                                renderer: renderer)
+                                                beginManualCameraControl: { [resources] in
+                                                    resources.beginManualCameraControl()
+                                                },
+                                                isTrajectoryModeActive: { [resources] in
+                                                    resources.isTrajectoryModeActive
+                                                })
         context.coordinator.cameraController = cameraController
         setupGestures(mtkView: mtkView,
                       cameraController: cameraController,
@@ -88,7 +94,7 @@ public struct UniverseView: UIViewRepresentable {
         if context.coordinator.currentSelectedPlanet != selectedPlanet {
             context.coordinator.currentSelectedPlanet = selectedPlanet
             if let name = selectedPlanet {
-                context.coordinator.renderer?.followPlanet(named: name)
+                resources.followPlanet(named: name)
             }
         }
     }

--- a/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraModeTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraModeTests.swift
@@ -1,0 +1,91 @@
+import CoreGraphics
+import simd
+import Testing
+@testable import MetalModule
+
+@MainActor
+@Test func followCameraModeMakesSteadyTargetTransaction() throws {
+    let mode = FollowCameraMode()
+    let transaction = try #require(mode.makeSteadyFollowTransaction(
+        named: "Mars",
+        snapshot: .followCameraTestSnapshot
+    ))
+
+    #expect(transaction.cameraTarget == SIMD3<Float>(1.52, 0, 0))
+}
+
+@MainActor
+@Test func followCameraModeReturnsNilForUnresolvedTarget() {
+    let mode = FollowCameraMode()
+
+    #expect(mode.makeSteadyFollowTransaction(named: "Venus",
+                                             snapshot: .followCameraTestSnapshot) == nil)
+    #expect(mode.makeTransitionFrame(named: "Venus",
+                                     snapshot: .followCameraTestSnapshot,
+                                     currentDistance: 3,
+                                     viewportSize: CGSize(width: 390, height: 844)) == nil)
+}
+
+@MainActor
+@Test func followCameraModeComputesFitDistance() throws {
+    let mode = FollowCameraMode()
+    let frame = try #require(mode.makeTransitionFrame(
+        named: "Mars",
+        snapshot: .followCameraTestSnapshot,
+        currentDistance: 3,
+        viewportSize: CGSize(width: 390, height: 844)
+    ))
+    let expectedDistance = CameraFit.distanceToFit(radius: 0.05,
+                                                   currentDistance: 3,
+                                                   viewportSize: CGSize(width: 390, height: 844))
+
+    #expect(frame.target == SIMD3<Float>(1.52, 0, 0))
+    #expect(abs(frame.distance - expectedDistance) < 0.000001)
+}
+
+@MainActor
+@Test func followCameraModeComputesFollowMinimumDistanceAndNearPlane() {
+    let mode = FollowCameraMode()
+    let minimumDistance = mode.minimumDistance(followingPlanetName: "Mars",
+                                               snapshot: .followCameraTestSnapshot,
+                                               baseMinimumDistance: 0.001)
+    let projection = mode.projectionParameters(
+        followingPlanetName: "Mars",
+        snapshot: .followCameraTestSnapshot,
+        cameraDistance: 0.08,
+        baseProjection: CameraProjectionParameters(nearPlane: 0.1,
+                                                   farPlane: 10000)
+    )
+
+    #expect(abs(minimumDistance - 0.0525) < 0.000001)
+    #expect(abs(projection.nearPlane - 0.015) < 0.000001)
+    #expect(projection.farPlane == 10000)
+}
+
+extension PreparedRenderSnapshot {
+    static var followCameraTestSnapshot: PreparedRenderSnapshot {
+        PreparedRenderSnapshot(frameID: 1,
+                               simulationTime: 0,
+                               planets: [
+                                followCameraTestPacket(name: "Sun",
+                                                       worldPosition: SIMD3<Float>(0, 0, 0),
+                                                       framingRadius: 0.2),
+                                followCameraTestPacket(name: "Mars",
+                                                       worldPosition: SIMD3<Float>(1.52, 0, 0),
+                                                       framingRadius: 0.05)
+                               ])
+    }
+
+    static func followCameraTestPacket(name: String,
+                                       worldPosition: SIMD3<Float>,
+                                       framingRadius: Float) -> PreparedPlanetRenderPacket {
+        PreparedPlanetRenderPacket(planetName: name,
+                                   meshes: [],
+                                   baseModelMatrix: matrix_identity_float4x4,
+                                   worldModelMatrix: matrix_identity_float4x4,
+                                   normalizedScale: 1,
+                                   primaryMeshRadius: framingRadius,
+                                   framingRadius: framingRadius,
+                                   worldPosition: worldPosition)
+    }
+}

--- a/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraOwnerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraOwnerTests.swift
@@ -1,0 +1,113 @@
+import CoreGraphics
+import simd
+import Testing
+@testable import MetalModule
+
+@MainActor
+@Test func followCameraOwnerStartsImmediateFollowTransition() {
+    let fixture = FollowCameraOwnerFixture()
+    let initialRevision = fixture.cameraState.revision
+
+    fixture.owner.followPlanet(named: "Mars",
+                               viewportSize: fixture.viewportSize)
+    fixture.owner.update(snapshot: fixture.source.latestSnapshot,
+                         delta: 0.1,
+                         viewportSize: fixture.viewportSize,
+                         isSuppressed: false)
+
+    #expect(fixture.cameraState.revision == initialRevision + 1)
+    #expect(fixture.cameraState.cameraTarget.x > 0)
+}
+
+@MainActor
+@Test func followCameraOwnerPendingFollowResolvesOnSnapshotUpdate() {
+    let fixture = FollowCameraOwnerFixture(latestSnapshot: nil)
+
+    fixture.owner.followPlanet(named: "Mars",
+                               viewportSize: fixture.viewportSize)
+    #expect(fixture.cameraState.revision == 0)
+
+    fixture.source.latestSnapshot = .followCameraTestSnapshot
+    fixture.owner.update(snapshot: fixture.source.latestSnapshot,
+                         delta: 0.1,
+                         viewportSize: fixture.viewportSize,
+                         isSuppressed: false)
+
+    #expect(fixture.cameraState.revision == 1)
+    #expect(fixture.cameraState.cameraTarget.x > 0)
+}
+
+@MainActor
+@Test func followCameraOwnerManualControlClearsTransitionButKeepsFollowTarget() {
+    let fixture = FollowCameraOwnerFixture()
+
+    fixture.owner.followPlanet(named: "Mars",
+                               viewportSize: fixture.viewportSize)
+    fixture.owner.beginManualCameraControl()
+    fixture.owner.update(snapshot: fixture.source.latestSnapshot,
+                         delta: 0.1,
+                         viewportSize: fixture.viewportSize,
+                         isSuppressed: false)
+
+    #expect(fixture.cameraState.cameraTarget == SIMD3<Float>(1.52, 0, 0))
+    #expect(fixture.cameraState.cameraDistance == 3)
+}
+
+@MainActor
+@Test func followCameraOwnerSuppressedUpdateDoesNotCommitFollowCamera() {
+    let fixture = FollowCameraOwnerFixture()
+
+    fixture.owner.followPlanet(named: "Mars",
+                               viewportSize: fixture.viewportSize)
+    fixture.owner.update(snapshot: fixture.source.latestSnapshot,
+                         delta: 0.1,
+                         viewportSize: fixture.viewportSize,
+                         isSuppressed: true)
+
+    #expect(fixture.cameraState.revision == 0)
+    #expect(fixture.cameraState.cameraTarget == SIMD3<Float>(0, 0, 0))
+}
+
+@MainActor
+@Test func followCameraOwnerProjectionUsesFollowedPlanetRadius() {
+    let fixture = FollowCameraOwnerFixture()
+    fixture.owner.followPlanet(named: "Mars",
+                               viewportSize: fixture.viewportSize)
+    let projection = fixture.owner.projectionParameters(
+        snapshot: fixture.source.latestSnapshot,
+        baseProjection: CameraProjectionParameters(nearPlane: 0.1,
+                                                   farPlane: 10000)
+    )
+
+    #expect(projection.nearPlane < CameraFit.defaultNearPlane)
+    #expect(projection.farPlane == 10000)
+}
+
+@MainActor
+private struct FollowCameraOwnerFixture {
+    let viewportSize = CGSize(width: 390, height: 844)
+    let source: FakeFollowCameraSnapshotSource
+    let provider: SnapshotProvider
+    let cameraState: CameraState
+    let owner: FollowCameraOwner
+
+    init(latestSnapshot: PreparedRenderSnapshot? = .followCameraTestSnapshot) {
+        source = FakeFollowCameraSnapshotSource(latestSnapshot: latestSnapshot)
+        cameraState = CameraState()
+        provider = SnapshotProvider(cameraState: cameraState,
+                                    snapshotSource: source)
+        owner = FollowCameraOwner(cameraState: cameraState,
+                                  snapshotProvider: provider)
+    }
+}
+
+@MainActor
+private final class FakeFollowCameraSnapshotSource: PreparedRenderSnapshotProviding {
+    var latestSnapshot: PreparedRenderSnapshot?
+
+    init(latestSnapshot: PreparedRenderSnapshot?) {
+        self.latestSnapshot = latestSnapshot
+    }
+
+    func requestPreparation(simulationTime: Float) {}
+}

--- a/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
@@ -135,7 +135,8 @@ private struct NavigationControllerFixture {
         cameraState = CameraState()
         provider = SnapshotProvider(cameraState: cameraState,
                                     snapshotSource: source)
-        cameraCoordinator = CameraCoordinator(cameraState: cameraState)
+        cameraCoordinator = CameraCoordinator(cameraState: cameraState,
+                                              snapshotProvider: provider)
         controller = NavigationController(snapshotProvider: provider,
                                           cameraCoordinator: cameraCoordinator,
                                           planets: testPlanets,

--- a/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
@@ -94,7 +94,8 @@ private struct TransferOrbitControllerFixture {
         cameraState = CameraState()
         provider = SnapshotProvider(cameraState: cameraState,
                                     snapshotSource: source)
-        cameraCoordinator = CameraCoordinator(cameraState: cameraState)
+        cameraCoordinator = CameraCoordinator(cameraState: cameraState,
+                                              snapshotProvider: provider)
         controller = TransferOrbitController(snapshotProvider: provider,
                                              cameraCoordinator: cameraCoordinator,
                                              planets: testPlanets,

--- a/RFC/DOT/30052026-CameraControllers.dot
+++ b/RFC/DOT/30052026-CameraControllers.dot
@@ -34,7 +34,7 @@ digraph CurrentGitChangesDependencies {
         LegendCommit [label="camera commit path", fillcolor="#dcfce7"];
         LegendSnapshot [label="snapshot derivation", fillcolor="#ede9fe"];
         LegendRender [label="render consumption", fillcolor="#ffedd5"];
-        LegendLegacy [label="legacy retained / out of scope", fillcolor="#f3f4f6"];
+        LegendMode [label="current camera mode", fillcolor="#dcfce7"];
     }
 
     subgraph cluster_composition {
@@ -131,6 +131,14 @@ digraph CurrentGitChangesDependencies {
             label="TransferPreviewCameraOwner\ncommits preview transactions",
             fillcolor="#dcfce7"
         ];
+        FollowCameraOwner [
+            label="FollowCameraOwner\nowns current follow lifecycle",
+            fillcolor="#dcfce7"
+        ];
+        FollowCameraMode [
+            label="FollowCameraMode\ncomputes follow transactions",
+            fillcolor="#dcfce7"
+        ];
         NavigationCameraMode [
             label="NavigationCameraMode\ncomputes transactions",
             fillcolor="#dcfce7"
@@ -163,7 +171,7 @@ digraph CurrentGitChangesDependencies {
         style="rounded";
 
         MetalRenderer [
-            label="MetalRenderer\nticks nav + composes render state",
+            label="MetalRenderer\nticks controllers + composes render state",
             fillcolor="#ffedd5"
         ];
         DrawFirstPass [
@@ -186,10 +194,6 @@ digraph CurrentGitChangesDependencies {
             label="TransferOrbitRenderState\ncontroller-owned preview handoff",
             fillcolor="#ffedd5"
         ];
-        LegacyFollowCamera [
-            label="legacy follow camera\nrenderer-owned, retained",
-            fillcolor="#f3f4f6"
-        ];
     }
 
     MetalModuleResources -> CameraState [
@@ -197,7 +201,7 @@ digraph CurrentGitChangesDependencies {
         color="#2563eb"
     ];
     MetalModuleResources -> CameraCoordinator [
-        label="creates with CameraState",
+        label="creates with CameraState + SnapshotProvider",
         color="#2563eb"
     ];
     MetalModuleResources -> SnapshotProvider [
@@ -213,8 +217,13 @@ digraph CurrentGitChangesDependencies {
         color="#2563eb"
     ];
     MetalModuleResources -> MetalRenderer [
-        label="injects NavigationController + TransferOrbitController",
+        label="injects controllers + CameraCoordinator",
         color="#2563eb"
+    ];
+    MetalModuleResources -> CameraCoordinator [
+        label="routes follow/manual commands",
+        color="#16a34a",
+        penwidth=2
     ];
     MetalModuleResources -> MetalModuleNavigationControlling [
         label="implements public facade",
@@ -323,8 +332,32 @@ digraph CurrentGitChangesDependencies {
         penwidth=2
     ];
     CameraCoordinator -> CameraState [
-        label="coordinates legacy camera updates",
+        label="refreshes derived camera values",
         color="#16a34a"
+    ];
+    CameraCoordinator -> FollowCameraOwner [
+        label="delegates follow lifecycle",
+        color="#16a34a",
+        penwidth=2
+    ];
+    FollowCameraOwner -> FollowCameraMode [
+        label="owns mode math",
+        color="#16a34a",
+        penwidth=2
+    ];
+    FollowCameraMode -> CameraTransaction [
+        label="returns transactions",
+        color="#16a34a",
+        penwidth=2
+    ];
+    FollowCameraOwner -> CameraState [
+        label="commits follow transactions",
+        color="#16a34a",
+        penwidth=2
+    ];
+    FollowCameraOwner -> SnapshotProvider [
+        label="reads latest scene snapshot",
+        color="#7c3aed"
     ];
     NavigationCameraOwner -> NavigationCameraMode [
         label="owns mode math",
@@ -388,8 +421,13 @@ digraph CurrentGitChangesDependencies {
         color="#ea580c"
     ];
     MetalRenderer -> CameraProjectionParameters [
-        label="composes base + preview + navigation projection",
+        label="composes base + follow + preview + navigation projection",
         color="#7c3aed",
+        penwidth=2
+    ];
+    MetalRenderer -> CameraCoordinator [
+        label="ticks follow mode; reads follow projection policy",
+        color="#16a34a",
         penwidth=2
     ];
     MetalRenderer -> SnapshotProvider [
@@ -429,16 +467,5 @@ digraph CurrentGitChangesDependencies {
     DrawFirstPass -> RouteRenderer [
         label="passes navigation route state",
         color="#ea580c"
-    ];
-
-    MetalRenderer -> LegacyFollowCamera [
-        label="retained non-navigation camera behavior",
-        color="#9ca3af",
-        style=dashed
-    ];
-    LegacyFollowCamera -> CameraState [
-        label="legacy setters still used",
-        color="#9ca3af",
-        style=dashed
     ];
 }


### PR DESCRIPTION
## Summary
- Extracted the planet-follow camera flow out of `MetalRenderer` into `FollowCameraMode` and `FollowCameraOwner`.
- Routed follow, manual-control, and navigation/transfer handoff behavior through `CameraCoordinator` and `MetalModuleResources`.
- Centralized shared camera fit math and updated the ADR/DOT documentation to reflect the new ownership model.
- Added focused tests for follow mode math, follow lifecycle ownership, and the existing navigation/transfer handoff paths.

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`
- Validation passed for the updated camera flow and the new follow-camera unit tests.

Resolves #171
Resolves  #308
Resolves #307
Resolves #295
