### PR TITLE
Route manual camera modes through coordinator transactions

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -44,9 +44,9 @@ final class CameraCoordinator {
          snapshotProvider: SnapshotProvider) {
         self.cameraState = cameraState
         self.snapshotProvider = snapshotProvider
-        zoomMode = .init(cameraState: cameraState)
-        orbitMode = .init(cameraState: cameraState)
-        trajectoryMode = .init(cameraState: cameraState)
+        zoomMode = .init()
+        orbitMode = .init()
+        trajectoryMode = .init()
         followCameraOwner = .init(cameraState: cameraState,
                                   snapshotProvider: snapshotProvider)
         navigationCameraOwner = .init(cameraState: cameraState)
@@ -82,18 +82,31 @@ final class CameraCoordinator {
     }
 
     func makeTranslation(with value: CGPoint) {
-        trajectoryMode.apply(translation: value)
+        let camera = TrajectoryCameraMode.CameraInput(distance: cameraState.cameraDistance,
+                                                      orientation: cameraState.cameraOrientation,
+                                                      target: cameraState.cameraTarget)
+        commitManualCameraTransaction(
+            trajectoryMode.makePanTransaction(translation: value,
+                                              camera: camera)
+        )
     }
 
     func makeRotation(with value: CGPoint, velocity: CGPoint) {
-        orbitMode.apply(horizontal: Float(value.x) * orbitSpeed,
-                        vertical: -Float(value.y) * orbitSpeed)
+        commitManualCameraTransaction(
+            orbitMode.makeOrbitTransaction(horizontal: Float(value.x) * orbitSpeed,
+                                           vertical: -Float(value.y) * orbitSpeed,
+                                           cameraOrientation: cameraState.cameraOrientation)
+        )
         orbitMode.addInertia(velocity: velocity)
     }
 
     func makeScale(with value: Float, velocity: CGFloat) {
-        zoomMode.apply(value: value)
-        zoomMode.addInertia(velocity: velocity)
+        commitManualCameraTransaction(
+            zoomMode.makeZoomTransaction(value: value,
+                                         currentDistance: cameraState.cameraDistance)
+        )
+        zoomMode.addInertia(velocity: velocity,
+                            currentDistance: cameraState.cameraDistance)
     }
 
     func followPlanet(named name: String,
@@ -149,12 +162,23 @@ final class CameraCoordinator {
     }
 
     private func update(delta: Float) {
-        zoomMode.update(delta: delta)
-        orbitMode.update(delta: delta)
+        commitManualCameraTransaction(
+            zoomMode.update(delta: delta,
+                            currentDistance: cameraState.cameraDistance)
+        )
+        commitManualCameraTransaction(
+            orbitMode.update(delta: delta,
+                             cameraOrientation: cameraState.cameraOrientation)
+        )
 
         if !isNavigationCameraActive {
             refreshCamera()
         }
+    }
+
+    private func commitManualCameraTransaction(_ transaction: CameraState.Transaction?) {
+        guard let transaction else { return }
+        cameraState.commit(transaction)
     }
 
     // MARK: Update loop

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
@@ -57,40 +57,6 @@ final class CameraState {
               distance: cameraDistance)
     }
 
-    // MARK: Setters
-
-    func set(cameraTarget: SIMD3<Float>) {
-        self.cameraTarget = cameraTarget
-        revision += 1
-    }
-
-    func set(cameraPosition: SIMD3<Float>) {
-        self.cameraPosition = cameraPosition
-        revision += 1
-    }
-
-    // MARK: Derivatives
-    func set(cameraDistance: Float) {
-        self.cameraDistance = cameraDistance
-        revision += 1
-    }
-
-    func set(cameraUp: SIMD3<Float>) {
-        self.cameraUp = cameraUp
-        revision += 1
-    }
-
-    func set(cameraOffset: SIMD3<Float>) {
-        self.cameraOffset = cameraOffset
-        revision += 1
-    }
-
-    // Probable deriative too
-    func set(cameraOrientation: simd_quatf) {
-        self.cameraOrientation = cameraOrientation
-        revision += 1
-    }
-
     func commit(_ transaction: Transaction) {
         if let cameraTarget = transaction.cameraTarget {
             self.cameraTarget = cameraTarget
@@ -108,14 +74,14 @@ final class CameraState {
             self.cameraOffset = cameraOffset
         }
         if let cameraOrientation = transaction.cameraOrientation {
-            self.cameraOrientation = cameraOrientation
+            self.cameraOrientation = simd_normalize(cameraOrientation)
         }
         revision += 1
     }
 
     // MARK: Common
 
-    func normalizeCameraOrientation() {
+    private func normalizeCameraOrientation() {
         cameraOrientation = simd_normalize(cameraOrientation)
     }
 
@@ -141,10 +107,12 @@ final class CameraState {
 
     /// Keeps zoom inside available range and outside of the followed planet
     /// - Parameter minDistance: Minimum allowed camera distance
-    func checkDistance(minDistance: Float) {
+    private func checkDistance(minDistance: Float) {
         let distance = cameraDistance
         let fixedDinstance = max(minDistance, min(distance, maxDistance))
-        set(cameraDistance: fixedDinstance)
+        guard fixedDinstance != distance else { return }
+
+        commit(Transaction(cameraDistance: fixedDinstance))
     }
 
     @discardableResult

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/OrbitCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/OrbitCameraMode.swift
@@ -11,29 +11,23 @@ import CoreFoundation
 /// Orbit camera mode
 final class OrbitCameraMode {
 
-    private unowned var cameraState: CameraState
-
     // Inertia
     private let orbitSpeed: Float = 0.01
     private var yawVelocity: Float = 0
     private var pitchVelocity: Float = 0
     private let damping: Float = 0.9
 
-    init(cameraState: CameraState) {
-        self.cameraState = cameraState
-    }
-
-    func apply(horizontal horizontalAngle: Float, vertical verticalAngle: Float) {
-        cameraState.normalizeCameraOrientation()
-
-        var cameraOrientation = cameraState.cameraOrientation
+    func makeOrbitTransaction(horizontal horizontalAngle: Float,
+                              vertical verticalAngle: Float,
+                              cameraOrientation currentOrientation: simd_quatf) -> CameraState.Transaction {
+        var cameraOrientation = simd_normalize(currentOrientation)
         let rightVector = normalize(cameraOrientation.act(SIMD3<Float>(1, 0, 0)))
         let upVector = normalize(cameraOrientation.act(SIMD3<Float>(0, 1, 0)))
         let horizontalRotation = simd_quatf(angle: horizontalAngle, axis: upVector)
         let verticalRotation = simd_quatf(angle: verticalAngle, axis: rightVector)
 
         cameraOrientation = simd_normalize(verticalRotation * horizontalRotation * cameraOrientation)
-        cameraState.set(cameraOrientation: cameraOrientation)
+        return CameraState.Transaction(cameraOrientation: cameraOrientation)
     }
 
     // MARK: Inertia
@@ -42,12 +36,14 @@ final class OrbitCameraMode {
         pitchVelocity = Float(velocity.y) * orbitSpeed * 0.1
     }
 
-    func update(delta: Float) {
+    func update(delta: Float,
+                cameraOrientation: simd_quatf) -> CameraState.Transaction? {
         guard yawVelocity != 0 || pitchVelocity != 0 else {
-            return
+            return nil
         }
-        apply(horizontal: yawVelocity * delta,
-              vertical: -pitchVelocity * delta)
+        let transaction = makeOrbitTransaction(horizontal: yawVelocity * delta,
+                                               vertical: -pitchVelocity * delta,
+                                               cameraOrientation: cameraOrientation)
 
         let factor = pow(damping, delta * 60)
         yawVelocity *= factor
@@ -55,5 +51,7 @@ final class OrbitCameraMode {
 
         if abs(yawVelocity) < 0.0001 { yawVelocity = 0 }
         if abs(pitchVelocity) < 0.0001 { pitchVelocity = 0 }
+
+        return transaction
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/TrajectoryCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/TrajectoryCameraMode.swift
@@ -11,28 +11,25 @@ import CoreFoundation
 /// Transformations for the trajectory camera mode
 final class TrajectoryCameraMode {
 
-    private unowned var cameraState: CameraState
+    struct CameraInput {
+        let distance: Float
+        let orientation: simd_quatf
+        let target: SIMD3<Float>
+    }
 
     private let trajectoryPanSpeed: Float = 1.0
 
-    init(cameraState: CameraState) {
-        self.cameraState = cameraState
-    }
-
-    func updateForPanTrajectory(width: Float,
-                                height: Float,
-                                translation: CGPoint,
-                                speed: Float) {
-        cameraState.normalizeCameraOrientation()
-
-        let cameraDistance = cameraState.cameraDistance
-        let cameraOrientation = cameraState.cameraOrientation
-
+    func makePanTransaction(width: Float,
+                            height: Float,
+                            translation: CGPoint,
+                            speed: Float,
+                            camera: CameraInput) -> CameraState.Transaction {
+        let cameraOrientation = simd_normalize(camera.orientation)
         let width = max(width, 1)
         let height = max(height, 1)
         let aspect = width / height
         let visibleHeight = (
-            2 * max(cameraDistance, CameraFit.minimumNearPlane)
+            2 * max(camera.distance, CameraFit.minimumNearPlane)
             * tan(CameraFit.verticalFieldOfView / 2)
         )
         let visibleWidth = visibleHeight * aspect
@@ -41,17 +38,19 @@ final class TrajectoryCameraMode {
         let rightVector = normalize(cameraOrientation.act(SIMD3<Float>(1, 0, 0)))
         let upVector = normalize(cameraOrientation.act(SIMD3<Float>(0, 1, 0)))
 
-        var cameraTarget = cameraState.cameraTarget
+        var cameraTarget = camera.target
         cameraTarget += (rightVector * horizontal) + (upVector * vertical)
-        cameraState.set(cameraTarget: cameraTarget)
+        return CameraState.Transaction(cameraTarget: cameraTarget)
     }
 
-    func apply(translation: CGPoint) {
-        updateForPanTrajectory(
+    func makePanTransaction(translation: CGPoint,
+                            camera: CameraInput) -> CameraState.Transaction {
+        makePanTransaction(
             width: Float(300),
             height: Float(400),
             translation: translation,
-            speed: trajectoryPanSpeed
+            speed: trajectoryPanSpeed,
+            camera: camera
         )
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/ZoomCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/ZoomCameraMode.swift
@@ -10,36 +10,35 @@ import CoreFoundation
 /// Zoom camera mode
 final class ZoomCameraMode {
 
-    private unowned var cameraState: CameraState
-
     private var zoomVelocity: Float = 0
     private let zoomSpeed: Float = 1.0
     private let damping: Float = 0.9
 
-    init(cameraState: CameraState) {
-        self.cameraState = cameraState
-    }
-
-    func apply(value: Float) {
+    func makeZoomTransaction(value: Float,
+                             currentDistance: Float) -> CameraState.Transaction {
         let zoomFactor = pow(value, zoomSpeed)
-        let cameraDistance = cameraState.cameraDistance / zoomFactor
-        cameraState.set(cameraDistance: cameraDistance)
+        let cameraDistance = currentDistance / zoomFactor
+        return CameraState.Transaction(cameraDistance: cameraDistance)
     }
 
     // MARK: Inertia
-    func addInertia(velocity: CGFloat) {
-        zoomVelocity = -Float(velocity) * cameraState.cameraDistance * 0.15
+    func addInertia(velocity: CGFloat,
+                    currentDistance: Float) {
+        zoomVelocity = -Float(velocity) * currentDistance * 0.15
     }
 
-    func update(delta: Float) {
+    func update(delta: Float,
+                currentDistance: Float) -> CameraState.Transaction? {
         guard zoomVelocity != 0 else {
-            return
+            return nil
         }
-        let cameraDistance = cameraState.cameraDistance + zoomVelocity * delta
-        cameraState.set(cameraDistance: cameraDistance)
+        let cameraDistance = currentDistance + zoomVelocity * delta
+        let transaction = CameraState.Transaction(cameraDistance: cameraDistance)
         let factor = pow(damping, delta * 60)
         zoomVelocity *= factor
 
         if abs(zoomVelocity) < 0.0001 { zoomVelocity = 0 }
+
+        return transaction
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraOwner.swift
@@ -64,16 +64,17 @@ final class NavigationCameraOwner {
     func commitTransition(routeID: UUID,
                           frame: CameraTransition.Frame) {
         self.routeID = routeID
-        cameraState.normalizeCameraOrientation()
-        let cameraOffset = cameraState.cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
+        let cameraOrientation = simd_normalize(cameraState.cameraOrientation)
+        let cameraOffset = cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
         let cameraPosition = cameraOffset + frame.target
-        let cameraUp = cameraState.cameraOrientation.act(SIMD3<Float>(0, 1, 0))
+        let cameraUp = cameraOrientation.act(SIMD3<Float>(0, 1, 0))
 
         cameraState.commit(CameraState.Transaction(cameraTarget: frame.target,
                                                    cameraPosition: cameraPosition,
                                                    cameraDistance: frame.distance,
                                                    cameraUp: cameraUp,
-                                                   cameraOffset: cameraOffset))
+                                                   cameraOffset: cameraOffset,
+                                                   cameraOrientation: cameraOrientation))
     }
 
     func commitDestination(destinationPosition: SIMD3<Float>) {

--- a/Modules/MetalModule/Sources/MetalModule/Camera/TransferPreviewCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/TransferPreviewCameraOwner.swift
@@ -16,15 +16,16 @@ final class TransferPreviewCameraOwner {
     }
 
     func commitTransition(frame: CameraTransition.Frame) {
-        cameraState.normalizeCameraOrientation()
-        let cameraOffset = cameraState.cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
+        let cameraOrientation = simd_normalize(cameraState.cameraOrientation)
+        let cameraOffset = cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
         let cameraPosition = cameraOffset + frame.target
-        let cameraUp = cameraState.cameraOrientation.act(SIMD3<Float>(0, 1, 0))
+        let cameraUp = cameraOrientation.act(SIMD3<Float>(0, 1, 0))
 
         cameraState.commit(CameraState.Transaction(cameraTarget: frame.target,
                                                    cameraPosition: cameraPosition,
                                                    cameraDistance: frame.distance,
                                                    cameraUp: cameraUp,
-                                                   cameraOffset: cameraOffset))
+                                                   cameraOffset: cameraOffset,
+                                                   cameraOrientation: cameraOrientation))
     }
 }

--- a/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraOwnerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraOwnerTests.swift
@@ -73,6 +73,7 @@ import Testing
     let fixture = FollowCameraOwnerFixture()
     fixture.owner.followPlanet(named: "Mars",
                                viewportSize: fixture.viewportSize)
+    fixture.cameraState.commit(CameraState.Transaction(cameraDistance: 0.08))
     let projection = fixture.owner.projectionParameters(
         snapshot: fixture.source.latestSnapshot,
         baseProjection: CameraProjectionParameters(nearPlane: 0.1,

--- a/Modules/MetalModule/Tests/MetalModuleTests/ManualCameraModeTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/ManualCameraModeTests.swift
@@ -1,0 +1,161 @@
+import CoreGraphics
+import Foundation
+import simd
+import Testing
+@testable import MetalModule
+
+@Test func orbitCameraModeProducesOrientationTransaction() throws {
+    let mode = OrbitCameraMode()
+    let initialOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
+
+    let transaction = mode.makeOrbitTransaction(horizontal: 0.2,
+                                                vertical: -0.1,
+                                                cameraOrientation: initialOrientation)
+
+    let orientation = try #require(transaction.cameraOrientation)
+    #expect(abs(simd_length(orientation.vector) - 1) < 0.000001)
+    #expect(abs(simd_dot(orientation.vector, initialOrientation.vector)) < 0.999)
+}
+
+@Test func orbitCameraModeInertiaProducesOptionalTransaction() throws {
+    let mode = OrbitCameraMode()
+    let initialOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
+
+    let idleTransaction = mode.update(delta: 1.0 / 60.0,
+                                      cameraOrientation: initialOrientation)
+    let idleTransactionIsNil: Bool
+    if case nil = idleTransaction {
+        idleTransactionIsNil = true
+    } else {
+        idleTransactionIsNil = false
+    }
+    #expect(idleTransactionIsNil)
+
+    mode.addInertia(velocity: CGPoint(x: 120, y: -80))
+    let transaction = try #require(mode.update(delta: 1.0 / 60.0,
+                                               cameraOrientation: initialOrientation))
+
+    _ = try #require(transaction.cameraOrientation)
+}
+
+@Test func zoomCameraModeProducesDistanceTransactions() throws {
+    let mode = ZoomCameraMode()
+
+    let pinchTransaction = mode.makeZoomTransaction(value: 2,
+                                                   currentDistance: 3)
+    #expect(pinchTransaction.cameraDistance == 1.5)
+
+    let idleTransaction = mode.update(delta: 1.0 / 60.0,
+                                      currentDistance: 3)
+    let idleTransactionIsNil: Bool
+    if case nil = idleTransaction {
+        idleTransactionIsNil = true
+    } else {
+        idleTransactionIsNil = false
+    }
+    #expect(idleTransactionIsNil)
+
+    mode.addInertia(velocity: 2,
+                    currentDistance: 3)
+    let inertiaTransaction = try #require(mode.update(delta: 1.0 / 60.0,
+                                                      currentDistance: 3))
+    #expect(abs((inertiaTransaction.cameraDistance ?? 0) - 2.985) < 0.000001)
+}
+
+@Test func trajectoryCameraModeProducesTargetTransaction() throws {
+    let mode = TrajectoryCameraMode()
+    let camera = TrajectoryCameraMode.CameraInput(
+        distance: 3,
+        orientation: simd_quatf(angle: 0,
+                                axis: SIMD3<Float>(0, 1, 0)),
+        target: .zero
+    )
+    let transaction = mode.makePanTransaction(width: 300,
+                                              height: 400,
+                                              translation: CGPoint(x: 30, y: 40),
+                                              speed: 1,
+                                              camera: camera)
+    let target = try #require(transaction.cameraTarget)
+    let visibleHeight = 2 * 3 * tan(CameraFit.verticalFieldOfView / 2)
+    let visibleWidth = visibleHeight * (300.0 / 400.0)
+    let expectedTarget = SIMD3<Float>(visibleWidth * 0.1,
+                                      visibleHeight * 0.1,
+                                      0)
+
+    #expect(simd_length(target - expectedTarget) < 0.000001)
+}
+
+@Test func manualCameraModesDoNotCallDirectCameraStateSetters() throws {
+    let modesDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Sources/MetalModule/Camera/Modes")
+    let modeFiles = [
+        "OrbitCameraMode.swift",
+        "ZoomCameraMode.swift",
+        "TrajectoryCameraMode.swift"
+    ]
+
+    for modeFile in modeFiles {
+        let source = try String(contentsOf: modesDirectory.appendingPathComponent(modeFile),
+                                encoding: .utf8)
+        #expect(!source.contains("cameraState.set("))
+        #expect(!source.contains("private unowned var cameraState"))
+    }
+}
+
+@MainActor
+@Test func cameraCoordinatorManualRotationCommitsOneTransaction() {
+    let fixture = ManualCameraCoordinatorFixture()
+    let initialRevision = fixture.cameraState.revision
+
+    fixture.cameraCoordinator.makeRotation(with: CGPoint(x: 10, y: 5),
+                                           velocity: .zero)
+
+    #expect(fixture.cameraState.revision == initialRevision + 1)
+}
+
+@MainActor
+@Test func cameraCoordinatorManualZoomCommitsOneTransaction() {
+    let fixture = ManualCameraCoordinatorFixture()
+    let initialRevision = fixture.cameraState.revision
+
+    fixture.cameraCoordinator.makeScale(with: 2,
+                                        velocity: 0)
+
+    #expect(fixture.cameraState.revision == initialRevision + 1)
+}
+
+@MainActor
+@Test func cameraCoordinatorTrajectoryPanCommitsOneTransaction() {
+    let fixture = ManualCameraCoordinatorFixture()
+    let initialRevision = fixture.cameraState.revision
+
+    fixture.cameraCoordinator.makeTranslation(with: CGPoint(x: 30, y: 40))
+
+    #expect(fixture.cameraState.revision == initialRevision + 1)
+}
+
+@MainActor
+private struct ManualCameraCoordinatorFixture {
+    let source = ManualCameraSnapshotSource()
+    let cameraState: CameraState
+    let snapshotProvider: SnapshotProvider
+    let cameraCoordinator: CameraCoordinator
+
+    init() {
+        cameraState = CameraState()
+        snapshotProvider = SnapshotProvider(cameraState: cameraState,
+                                            snapshotSource: source)
+        cameraCoordinator = CameraCoordinator(cameraState: cameraState,
+                                              snapshotProvider: snapshotProvider)
+    }
+}
+
+@MainActor
+private final class ManualCameraSnapshotSource: PreparedRenderSnapshotProviding {
+    var latestSnapshot: PreparedRenderSnapshot?
+
+    func requestPreparation(simulationTime: Float) {}
+}

--- a/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import simd
 import Testing
 @testable import MetalModule
@@ -11,7 +12,7 @@ import Testing
 
     #expect(fixture.controller.navigationSnapshot.state == .running)
     #expect(fixture.controller.routeRenderState.route?.destinationName == "Mars")
-    #expect(fixture.controller.routeRenderState.progress == 0)
+    #expect(fixture.controller.routeRenderState.progress < 0.001)
 }
 
 @MainActor

--- a/RFC/DOT/30052026-CameraControllers.dot
+++ b/RFC/DOT/30052026-CameraControllers.dot
@@ -112,7 +112,7 @@ digraph CurrentGitChangesDependencies {
         style="rounded";
 
         CameraCoordinator [
-            label="CameraCoordinator\nroutes camera ownership",
+            label="CameraCoordinator\nroutes camera ownership\ncommits manual transactions",
             fillcolor="#dcfce7"
         ];
         NavigationCameraCoordinating [
@@ -139,12 +139,24 @@ digraph CurrentGitChangesDependencies {
             label="FollowCameraMode\ncomputes follow transactions",
             fillcolor="#dcfce7"
         ];
+        OrbitCameraMode [
+            label="OrbitCameraMode\ncomputes orientation transactions",
+            fillcolor="#dcfce7"
+        ];
+        ZoomCameraMode [
+            label="ZoomCameraMode\ncomputes distance transactions",
+            fillcolor="#dcfce7"
+        ];
+        TrajectoryCameraMode [
+            label="TrajectoryCameraMode\ncomputes target transactions",
+            fillcolor="#dcfce7"
+        ];
         NavigationCameraMode [
             label="NavigationCameraMode\ncomputes transactions",
             fillcolor="#dcfce7"
         ];
         CameraState [
-            label="CameraState\ncanonical camera variables + revision",
+            label="CameraState\ncanonical camera variables + revision\ncommit is mutation boundary",
             fillcolor="#dcfce7"
         ];
         CameraTransaction [
@@ -332,8 +344,39 @@ digraph CurrentGitChangesDependencies {
         penwidth=2
     ];
     CameraCoordinator -> CameraState [
-        label="refreshes derived camera values",
-        color="#16a34a"
+        label="commits manual transactions\n+ refreshes derived values",
+        color="#16a34a",
+        penwidth=2
+    ];
+    CameraCoordinator -> OrbitCameraMode [
+        label="routes pan / inertia",
+        color="#16a34a",
+        penwidth=2
+    ];
+    CameraCoordinator -> ZoomCameraMode [
+        label="routes pinch / inertia",
+        color="#16a34a",
+        penwidth=2
+    ];
+    CameraCoordinator -> TrajectoryCameraMode [
+        label="routes trajectory pan",
+        color="#16a34a",
+        penwidth=2
+    ];
+    OrbitCameraMode -> CameraTransaction [
+        label="returns orientation transaction",
+        color="#16a34a",
+        penwidth=2
+    ];
+    ZoomCameraMode -> CameraTransaction [
+        label="returns distance transaction",
+        color="#16a34a",
+        penwidth=2
+    ];
+    TrajectoryCameraMode -> CameraTransaction [
+        label="returns target transaction",
+        color="#16a34a",
+        penwidth=2
     ];
     CameraCoordinator -> FollowCameraOwner [
         label="delegates follow lifecycle",


### PR DESCRIPTION
## Summary
- Refactor manual orbit, zoom, and trajectory camera paths to emit `CameraState.Transaction` values instead of mutating `CameraState` directly.
- Route all manual camera commits through `CameraCoordinator`, keeping coordinator-visible ownership for gestures and inertia.
- Tighten the camera mutation boundary by removing direct setter-style mutation from `CameraState` and normalizing orientation at commit time.
- Update the camera dependency graph to reflect the new manual transaction flow.

## Testing
- Added focused unit tests for orbit, zoom, and trajectory transaction generation.
- Added coordinator tests covering manual rotation, zoom, and trajectory pan revision commits.
- Updated existing follow/navigation tests for the current transaction behavior.
- Validated with `xcodebuild` for the app scheme and the `MetalModuleTests` scheme; both passed.

Resolves #304