### PR TITLE
Refine camera transactions and snapshot caching

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -57,12 +57,12 @@ final class CameraCoordinator {
         cameraState.currentCameraTransitionFrame
     }
 
-    var cameraFollowTransitionDuration: Float {
-        cameraState.cameraFollowTransitionDuration
+    var currentCameraPose: CameraPose {
+        cameraState.pose
     }
 
-    var cameraPosition: SIMD3<Float> {
-        cameraState.cameraPosition
+    var cameraFollowTransitionDuration: Float {
+        cameraState.cameraFollowTransitionDuration
     }
 
     var cameraTarget: SIMD3<Float> {
@@ -156,7 +156,7 @@ final class CameraCoordinator {
     /// centralized in `CameraState`/`SnapshotProvider`.
     func refreshCamera(snapshot: PreparedRenderSnapshot? = nil) {
         let snapshot = snapshot ?? snapshotProvider.latestSnapshot
-        cameraState.refreshDerivedCameraValues(
+        cameraState.enforceCameraConstraints(
             minDistance: followCameraOwner.minimumAllowedCameraDistance(snapshot: snapshot)
         )
     }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
@@ -7,27 +7,57 @@
 
 import simd
 
+struct CameraPose: Equatable {
+    let target: SIMD3<Float>
+    let distance: Float
+    let orientation: simd_quatf
+
+    var offset: SIMD3<Float> {
+        orientation.act(SIMD3<Float>(0, 0, distance))
+    }
+
+    var position: SIMD3<Float> {
+        target + offset
+    }
+
+    var upVector: SIMD3<Float> {
+        orientation.act(SIMD3<Float>(0, 1, 0))
+    }
+
+    var transitionFrame: CameraTransition.Frame {
+        .init(target: target,
+              distance: distance)
+    }
+
+    func makeRenderViewMatrix() -> float4x4 {
+        float4x4.lookAt(
+            eye: offset,
+            target: .zero,
+            upVector: upVector
+        )
+    }
+}
+
 /// Owns canonical camera variables and camera revision metadata
 final class CameraState {
+    struct DirtyFields: OptionSet, Equatable {
+        let rawValue: Int
+
+        static let target = DirtyFields(rawValue: 1 << 0)
+        static let distance = DirtyFields(rawValue: 1 << 1)
+        static let orientation = DirtyFields(rawValue: 1 << 2)
+    }
+
     struct Transaction {
         var cameraTarget: SIMD3<Float>?
-        var cameraPosition: SIMD3<Float>?
         var cameraDistance: Float?
-        var cameraUp: SIMD3<Float>?
-        var cameraOffset: SIMD3<Float>?
         var cameraOrientation: simd_quatf?
 
         init(cameraTarget: SIMD3<Float>? = nil,
-             cameraPosition: SIMD3<Float>? = nil,
              cameraDistance: Float? = nil,
-             cameraUp: SIMD3<Float>? = nil,
-             cameraOffset: SIMD3<Float>? = nil,
              cameraOrientation: simd_quatf? = nil) {
             self.cameraTarget = cameraTarget
-            self.cameraPosition = cameraPosition
             self.cameraDistance = cameraDistance
-            self.cameraUp = cameraUp
-            self.cameraOffset = cameraOffset
             self.cameraOrientation = cameraOrientation
         }
     }
@@ -39,93 +69,60 @@ final class CameraState {
 
     private(set) var cameraDistance: Float = 3 // !
     private(set) var cameraTarget = SIMD3<Float>(0, 0, 0) // !
-
     private(set) var cameraOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0)) // !
-
-    /// Derivatives
-    /// Derived values such as camera position, offset, up vector, view matrix,
-    /// and projection matrix should generally belong to immutable snapshots instead of being
-    /// independently mutable state.
-    /// This reduces stale or contradictory camera data.
-    private(set) var cameraPosition = SIMD3<Float>(0, 0, 0)
-    private(set) var cameraUp = SIMD3<Float>(0, 1, 0)
-    private(set) var cameraOffset = SIMD3<Float>(0, 0, 3)
     private(set) var revision = 0
+    private(set) var lastDirtyFields: DirtyFields = []
+
+    var pose: CameraPose {
+        CameraPose(target: cameraTarget,
+                   distance: cameraDistance,
+                   orientation: cameraOrientation)
+    }
 
     var currentCameraTransitionFrame: CameraTransition.Frame {
-        .init(target: cameraTarget,
-              distance: cameraDistance)
+        pose.transitionFrame
     }
 
-    func commit(_ transaction: Transaction) {
+    @discardableResult
+    func commit(_ transaction: Transaction) -> DirtyFields {
+        var dirtyFields: DirtyFields = []
+
         if let cameraTarget = transaction.cameraTarget {
-            self.cameraTarget = cameraTarget
-        }
-        if let cameraPosition = transaction.cameraPosition {
-            self.cameraPosition = cameraPosition
+            if self.cameraTarget != cameraTarget {
+                self.cameraTarget = cameraTarget
+                dirtyFields.insert(.target)
+            }
         }
         if let cameraDistance = transaction.cameraDistance {
-            self.cameraDistance = cameraDistance
-        }
-        if let cameraUp = transaction.cameraUp {
-            self.cameraUp = cameraUp
-        }
-        if let cameraOffset = transaction.cameraOffset {
-            self.cameraOffset = cameraOffset
+            if self.cameraDistance != cameraDistance {
+                self.cameraDistance = cameraDistance
+                dirtyFields.insert(.distance)
+            }
         }
         if let cameraOrientation = transaction.cameraOrientation {
-            self.cameraOrientation = simd_normalize(cameraOrientation)
+            let normalizedOrientation = simd_normalize(cameraOrientation)
+            if self.cameraOrientation != normalizedOrientation {
+                self.cameraOrientation = normalizedOrientation
+                dirtyFields.insert(.orientation)
+            }
         }
+
+        guard !dirtyFields.isEmpty else {
+            return []
+        }
+        lastDirtyFields = dirtyFields
         revision += 1
-    }
-
-    // MARK: Common
-
-    private func normalizeCameraOrientation() {
-        cameraOrientation = simd_normalize(cameraOrientation)
-    }
-
-    func makeViewMatrix() -> float4x4 {
-        normalizeCameraOrientation()
-
-        cameraOffset = cameraOrientation.act(SIMD3<Float>(0, 0, cameraDistance))
-        // looks loke cameraPosition, cameraOffset and cameraUp is no sense to change outside of the class
-        // cameraTarget is resetted each frame while following a planet
-        cameraPosition = cameraOffset + cameraTarget
-        cameraUp = cameraOrientation.act(SIMD3<Float>(0, 1, 0))
-
-        // Conslusion:
-        // only cameraOrientation persists after each frame MetalRenderer updates
-        // All other changes, probably, dead
-
-        return float4x4.lookAt(
-            eye: cameraPosition,
-            target: cameraTarget,
-            upVector: cameraUp
-        )
+        return dirtyFields
     }
 
     /// Keeps zoom inside available range and outside of the followed planet
     /// - Parameter minDistance: Minimum allowed camera distance
-    private func checkDistance(minDistance: Float) {
-        let distance = cameraDistance
-        let fixedDinstance = max(minDistance, min(distance, maxDistance))
-        guard fixedDinstance != distance else { return }
-
-        commit(Transaction(cameraDistance: fixedDinstance))
-    }
-
     @discardableResult
-    func refreshDerivedCameraValues(minDistance: Float) -> float4x4 {
-        checkDistance(minDistance: minDistance)
-        return makeViewMatrix()
-    }
+    func enforceCameraConstraints(minDistance: Float) -> DirtyFields {
+        let distance = cameraDistance
+        let fixedDistance = max(minDistance, min(distance, maxDistance))
+        guard fixedDistance != distance else { return [] }
 
-    func makeRenderViewMatrix() -> float4x4 {
-        float4x4.lookAt(
-            eye: cameraOffset,
-            target: .zero,
-            upVector: cameraUp
-        )
+        return commit(Transaction(cameraDistance: fixedDistance))
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/FollowCameraMode.swift
@@ -51,15 +51,9 @@ final class FollowCameraMode {
     func makeTransitionTransaction(frame: CameraTransition.Frame,
                                    cameraOrientation: simd_quatf) -> CameraState.Transaction {
         let orientation = simd_normalize(cameraOrientation)
-        let cameraOffset = orientation.act(SIMD3<Float>(0, 0, frame.distance))
-        let cameraPosition = cameraOffset + frame.target
-        let cameraUp = orientation.act(SIMD3<Float>(0, 1, 0))
 
         return CameraState.Transaction(cameraTarget: frame.target,
-                                       cameraPosition: cameraPosition,
                                        cameraDistance: frame.distance,
-                                       cameraUp: cameraUp,
-                                       cameraOffset: cameraOffset,
                                        cameraOrientation: orientation)
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/NavigationCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/NavigationCameraMode.swift
@@ -13,16 +13,18 @@ final class NavigationCameraMode {
     func makeNavigationFollowTransaction(currentPoint: SIMD3<Float>,
                                          destinationPosition: SIMD3<Float>,
                                          trailingOffset: SIMD3<Float>) -> CameraState.Transaction {
-        let cameraEye = currentPoint + trailingOffset
         let localTarget = destinationPosition - currentPoint
-        let localEye = cameraEye - currentPoint
-        let cameraUp = makeCameraUp(viewDirection: normalize(localTarget - localEye))
+        let localEye = trailingOffset
+        let viewDirectionInput = localTarget - localEye
+        let viewDirection = simd_length_squared(viewDirectionInput) > 0.000001
+        ? normalize(viewDirectionInput)
+        : SIMD3<Float>(0, 0, -1)
+        let cameraUp = makeCameraUp(viewDirection: viewDirection)
 
         return CameraState.Transaction(cameraTarget: currentPoint,
-                                       cameraPosition: cameraEye,
                                        cameraDistance: max(simd_length(localEye), CameraFit.minimumNearPlane),
-                                       cameraUp: cameraUp,
-                                       cameraOffset: localEye)
+                                       cameraOrientation: makeCameraOrientation(localEye: localEye,
+                                                                                cameraUp: cameraUp))
     }
 
     func makeNavigationArrivalTransaction(position: SIMD3<Float>,
@@ -34,10 +36,9 @@ final class NavigationCameraMode {
         let cameraUp = makeCameraUp(viewDirection: viewDirection)
 
         return CameraState.Transaction(cameraTarget: target,
-                                       cameraPosition: position,
                                        cameraDistance: max(simd_length(localEye), CameraFit.minimumNearPlane),
-                                       cameraUp: cameraUp,
-                                       cameraOffset: localEye)
+                                       cameraOrientation: makeCameraOrientation(localEye: localEye,
+                                                                                cameraUp: cameraUp))
     }
 
     func makeDestinationTransaction(destinationPosition: SIMD3<Float>,
@@ -61,8 +62,6 @@ final class NavigationCameraMode {
 
         return CameraState.Transaction(cameraTarget: destinationPosition,
                                        cameraDistance: max(simd_length(localEye), CameraFit.minimumNearPlane),
-                                       cameraUp: cameraUpDirection,
-                                       cameraOffset: localEye,
                                        cameraOrientation: cameraOrientation)
     }
 
@@ -73,5 +72,24 @@ final class NavigationCameraMode {
         : fallbackUp
         let right = normalize(simd_cross(candidateUp, viewDirection))
         return normalize(simd_cross(viewDirection, right))
+    }
+
+    private func makeCameraOrientation(localEye: SIMD3<Float>,
+                                       cameraUp: SIMD3<Float>) -> simd_quatf {
+        let forward = simd_length_squared(localEye) > 0.000001
+        ? normalize(localEye)
+        : SIMD3<Float>(0, 0, 1)
+        let upSeed = simd_length_squared(cameraUp) > 0.000001
+        ? normalize(cameraUp)
+        : SIMD3<Float>(0, 1, 0)
+        let candidateUp = abs(simd_dot(forward, upSeed)) > 0.94
+        ? SIMD3<Float>(1, 0, 0)
+        : upSeed
+        let right = normalize(simd_cross(candidateUp, forward))
+        let cameraUpDirection = normalize(simd_cross(forward, right))
+
+        return simd_normalize(simd_quatf(
+            float3x3(columns: (right, cameraUpDirection, forward))
+        ))
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraCoordinating.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraCoordinating.swift
@@ -16,8 +16,8 @@ import simd
 @MainActor
 protocol NavigationCameraCoordinating: AnyObject {
     var currentCameraTransitionFrame: CameraTransition.Frame { get }
+    var currentCameraPose: CameraPose { get }
     var cameraFollowTransitionDuration: Float { get }
-    var cameraPosition: SIMD3<Float> { get }
     var cameraTarget: SIMD3<Float> { get }
     var cameraDistance: Float { get }
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/NavigationCameraOwner.swift
@@ -65,22 +65,17 @@ final class NavigationCameraOwner {
                           frame: CameraTransition.Frame) {
         self.routeID = routeID
         let cameraOrientation = simd_normalize(cameraState.cameraOrientation)
-        let cameraOffset = cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
-        let cameraPosition = cameraOffset + frame.target
-        let cameraUp = cameraOrientation.act(SIMD3<Float>(0, 1, 0))
 
         cameraState.commit(CameraState.Transaction(cameraTarget: frame.target,
-                                                   cameraPosition: cameraPosition,
                                                    cameraDistance: frame.distance,
-                                                   cameraUp: cameraUp,
-                                                   cameraOffset: cameraOffset,
                                                    cameraOrientation: cameraOrientation))
     }
 
     func commitDestination(destinationPosition: SIMD3<Float>) {
+        let pose = cameraState.pose
         guard let transaction = navigationMode.makeDestinationTransaction(destinationPosition: destinationPosition,
-                                                                         cameraPosition: cameraState.cameraPosition,
-                                                                         cameraUp: cameraState.cameraUp) else {
+                                                                         cameraPosition: pose.position,
+                                                                         cameraUp: pose.upVector) else {
             return
         }
         cameraState.commit(transaction)

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider.swift
@@ -8,7 +8,7 @@
 import CoreGraphics
 import simd
 
-struct CameraProjectionParameters {
+struct CameraProjectionParameters: Equatable {
     let nearPlane: Float
     let farPlane: Float
 }
@@ -21,9 +21,19 @@ final class SnapshotProvider {
     // Input
     private let cameraState: CameraState
     private let snapshotSource: PreparedRenderSnapshotProviding
+    private var cachedCameraSnapshot: CameraSnapshot?
+    private var cachedDependencyKey: CameraSnapshotDependencyKey?
 
     var latestSnapshot: PreparedRenderSnapshot? {
         snapshotSource.latestSnapshot
+    }
+
+    private struct CameraSnapshotDependencyKey: Equatable {
+        let cameraRevision: Int
+        let cameraDirtyFields: CameraState.DirtyFields
+        let sceneFrameID: UInt64?
+        let viewportSize: CGSize
+        let projection: CameraProjectionParameters
     }
 
     struct CameraSnapshot {
@@ -33,6 +43,8 @@ final class SnapshotProvider {
         let cameraPosition: SIMD3<Float>
         let viewportSize: CGSize
         let cameraRevision: Int
+        let cameraDirtyFields: CameraState.DirtyFields
+        let sceneFrameID: UInt64?
     }
 
     init(cameraState: CameraState,
@@ -52,6 +64,20 @@ final class SnapshotProvider {
 
     func makeCameraSnapshot(viewportSize: CGSize,
                             projection: CameraProjectionParameters) -> CameraSnapshot {
+        let sceneFrameID = latestSnapshot?.frameID
+        let dependencyKey = CameraSnapshotDependencyKey(
+            cameraRevision: cameraState.revision,
+            cameraDirtyFields: cameraState.lastDirtyFields,
+            sceneFrameID: sceneFrameID,
+            viewportSize: viewportSize,
+            projection: projection
+        )
+        if dependencyKey == cachedDependencyKey,
+           let cachedCameraSnapshot {
+            return cachedCameraSnapshot
+        }
+
+        let cameraPose = cameraState.pose
         let aspect = Float(viewportSize.width / max(viewportSize.height, 1))
         let projectionMatrix = float4x4.perspective(
             fov: CameraFit.verticalFieldOfView,
@@ -60,11 +86,16 @@ final class SnapshotProvider {
             far: max(projection.farPlane, projection.nearPlane + CameraFit.minimumNearPlane)
         )
 
-        return CameraSnapshot(renderViewMatrix: cameraState.makeRenderViewMatrix(),
-                              projectionMatrix: projectionMatrix,
-                              sceneOrigin: cameraState.cameraTarget,
-                              cameraPosition: cameraState.cameraOffset,
-                              viewportSize: viewportSize,
-                              cameraRevision: cameraState.revision)
+        let cameraSnapshot = CameraSnapshot(renderViewMatrix: cameraPose.makeRenderViewMatrix(),
+                                            projectionMatrix: projectionMatrix,
+                                            sceneOrigin: cameraPose.target,
+                                            cameraPosition: cameraPose.offset,
+                                            viewportSize: viewportSize,
+                                            cameraRevision: cameraState.revision,
+                                            cameraDirtyFields: cameraState.lastDirtyFields,
+                                            sceneFrameID: sceneFrameID)
+        cachedDependencyKey = dependencyKey
+        cachedCameraSnapshot = cameraSnapshot
+        return cameraSnapshot
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/TransferPreviewCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/TransferPreviewCameraOwner.swift
@@ -17,15 +17,9 @@ final class TransferPreviewCameraOwner {
 
     func commitTransition(frame: CameraTransition.Frame) {
         let cameraOrientation = simd_normalize(cameraState.cameraOrientation)
-        let cameraOffset = cameraOrientation.act(SIMD3<Float>(0, 0, frame.distance))
-        let cameraPosition = cameraOffset + frame.target
-        let cameraUp = cameraOrientation.act(SIMD3<Float>(0, 1, 0))
 
         cameraState.commit(CameraState.Transaction(cameraTarget: frame.target,
-                                                   cameraPosition: cameraPosition,
                                                    cameraDistance: frame.distance,
-                                                   cameraUp: cameraUp,
-                                                   cameraOffset: cameraOffset,
                                                    cameraOrientation: cameraOrientation))
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController+Camera.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController+Camera.swift
@@ -92,13 +92,14 @@ extension NavigationController {
         let arrivalDistance = distanceToFitPlanet(radius: destinationRadius)
         * navigationArrivalDistanceMultiplier
         if navigationArrivalRouteID != route.id {
-            let currentOffset = cameraCoordinator.cameraPosition - destinationPosition
+            let currentPose = cameraCoordinator.currentCameraPose
+            let currentOffset = currentPose.position - destinationPosition
             let existingDirection = simd_length_squared(currentOffset) > 0.000001
             ? normalize(currentOffset)
             : SIMD3<Float>(0, 0, 1)
 
             navigationArrivalRouteID = route.id
-            navigationArrivalStartCameraPosition = cameraCoordinator.cameraPosition
+            navigationArrivalStartCameraPosition = currentPose.position
             navigationArrivalStartTarget = cameraCoordinator.cameraTarget
             navigationArrivalTargetOffset = existingDirection * arrivalDistance
             navigationArrivalProgress = 0

--- a/Modules/MetalModule/Tests/MetalModuleTests/CameraStateTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/CameraStateTests.swift
@@ -1,0 +1,59 @@
+import simd
+import Testing
+@testable import MetalModule
+
+@Test func cameraStateCommitRecordsDirtyFieldsAndIncrementsRevisionOnce() {
+    let cameraState = CameraState()
+    let orientation = simd_quatf(angle: 0.25,
+                                 axis: SIMD3<Float>(0, 1, 0))
+
+    let dirtyFields = cameraState.commit(CameraState.Transaction(
+        cameraTarget: SIMD3<Float>(1, 2, 3),
+        cameraDistance: 4,
+        cameraOrientation: orientation
+    ))
+
+    #expect(dirtyFields == [.target, .distance, .orientation])
+    #expect(cameraState.lastDirtyFields == [.target, .distance, .orientation])
+    #expect(cameraState.revision == 1)
+}
+
+@Test func cameraStateUnchangedCommitDoesNotIncrementRevision() {
+    let cameraState = CameraState()
+    let initialRevision = cameraState.revision
+
+    let dirtyFields = cameraState.commit(CameraState.Transaction(
+        cameraTarget: cameraState.cameraTarget,
+        cameraDistance: cameraState.cameraDistance,
+        cameraOrientation: cameraState.cameraOrientation
+    ))
+
+    #expect(dirtyFields.isEmpty)
+    #expect(cameraState.lastDirtyFields.isEmpty)
+    #expect(cameraState.revision == initialRevision)
+}
+
+@Test func cameraStateNormalizesCommittedOrientation() {
+    let cameraState = CameraState()
+    let orientation = simd_quatf(vector: SIMD4<Float>(0, 0.5, 0, 0.5))
+
+    cameraState.commit(CameraState.Transaction(cameraOrientation: orientation))
+
+    #expect(abs(simd_length(cameraState.cameraOrientation.vector) - 1) < 0.000001)
+}
+
+@Test func cameraStateDistanceConstraintCommitsOnlyWhenDistanceChanges() {
+    let cameraState = CameraState()
+    cameraState.commit(CameraState.Transaction(cameraDistance: 0.1))
+    let revisionBeforeClamp = cameraState.revision
+
+    let dirtyFields = cameraState.enforceCameraConstraints(minDistance: 0.5)
+    let revisionAfterClamp = cameraState.revision
+    let unchangedDirtyFields = cameraState.enforceCameraConstraints(minDistance: 0.5)
+
+    #expect(dirtyFields == [.distance])
+    #expect(cameraState.cameraDistance == 0.5)
+    #expect(revisionAfterClamp == revisionBeforeClamp + 1)
+    #expect(unchangedDirtyFields.isEmpty)
+    #expect(cameraState.revision == revisionAfterClamp)
+}

--- a/Modules/MetalModule/Tests/MetalModuleTests/SnapshotProviderTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/SnapshotProviderTests.swift
@@ -45,6 +45,130 @@ import Testing
 }
 
 @MainActor
+@Test func snapshotProviderReusesEquivalentSnapshotForUnchangedDependencies() {
+    let cameraState = CameraState()
+    let source = FakePreparedRenderSnapshotSource(
+        latestSnapshot: PreparedRenderSnapshot(frameID: 1,
+                                               simulationTime: 0,
+                                               planets: [])
+    )
+    let provider = SnapshotProvider(cameraState: cameraState,
+                                    snapshotSource: source)
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+
+    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                    projection: projection)
+    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                     projection: projection)
+
+    expectCameraSnapshot(secondSnapshot,
+                         equals: firstSnapshot)
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenCameraRevisionChanges() {
+    let cameraState = CameraState()
+    let source = FakePreparedRenderSnapshotSource(
+        latestSnapshot: PreparedRenderSnapshot(frameID: 1,
+                                               simulationTime: 0,
+                                               planets: [])
+    )
+    let provider = SnapshotProvider(cameraState: cameraState,
+                                    snapshotSource: source)
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                    projection: projection)
+
+    cameraState.commit(CameraState.Transaction(cameraDistance: 4))
+    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                     projection: projection)
+
+    #expect(secondSnapshot.cameraRevision == firstSnapshot.cameraRevision + 1)
+    #expect(secondSnapshot.cameraDirtyFields == [.distance])
+    expectVector(secondSnapshot.cameraPosition,
+                 equals: SIMD3<Float>(0, 0, 4))
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenSceneFrameChanges() {
+    let source = FakePreparedRenderSnapshotSource(
+        latestSnapshot: PreparedRenderSnapshot(frameID: 1,
+                                               simulationTime: 0,
+                                               planets: [])
+    )
+    let provider = SnapshotProvider(snapshotSource: source)
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                    projection: projection)
+
+    source.latestSnapshot = PreparedRenderSnapshot(frameID: 2,
+                                                   simulationTime: 1,
+                                                   planets: [])
+    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                     projection: projection)
+
+    #expect(firstSnapshot.sceneFrameID == 1)
+    #expect(secondSnapshot.sceneFrameID == 2)
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenViewportOrProjectionChanges() {
+    let provider = SnapshotProvider(snapshotSource: FakePreparedRenderSnapshotSource())
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
+                                                    projection: projection)
+
+    let viewportSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 100, height: 100),
+                                                       projection: projection)
+    let nearPlaneSnapshot = provider.makeCameraSnapshot(
+        viewportSize: CGSize(width: 100, height: 100),
+        projection: CameraProjectionParameters(nearPlane: 0.2,
+                                               farPlane: 100)
+    )
+    let farPlaneSnapshot = provider.makeCameraSnapshot(
+        viewportSize: CGSize(width: 100, height: 100),
+        projection: CameraProjectionParameters(nearPlane: 0.2,
+                                               farPlane: 200)
+    )
+
+    #expect(viewportSnapshot.viewportSize == CGSize(width: 100, height: 100))
+    #expect(viewportSnapshot.projectionMatrix[0][0] != firstSnapshot.projectionMatrix[0][0])
+    #expect(nearPlaneSnapshot.projectionMatrix[2][2] != viewportSnapshot.projectionMatrix[2][2])
+    #expect(farPlaneSnapshot.projectionMatrix[2][2] != nearPlaneSnapshot.projectionMatrix[2][2])
+}
+
+@MainActor
+@Test func snapshotProviderDerivesSnapshotFromCanonicalCameraPose() {
+    let cameraState = CameraState()
+    let source = FakePreparedRenderSnapshotSource()
+    let provider = SnapshotProvider(cameraState: cameraState,
+                                    snapshotSource: source)
+    let orientation = simd_quatf(angle: .pi / 2,
+                                 axis: SIMD3<Float>(0, 1, 0))
+    cameraState.commit(CameraState.Transaction(cameraTarget: SIMD3<Float>(1, 2, 3),
+                                               cameraDistance: 5,
+                                               cameraOrientation: orientation))
+
+    let cameraSnapshot = provider.makeCameraSnapshot(
+        viewportSize: CGSize(width: 200, height: 100),
+        projection: CameraProjectionParameters(nearPlane: 0.1,
+                                               farPlane: 100)
+    )
+    let expectedPose = cameraState.pose
+
+    expectVector(cameraSnapshot.sceneOrigin,
+                 equals: expectedPose.target)
+    expectVector(cameraSnapshot.cameraPosition,
+                 equals: expectedPose.offset)
+    expectMatrix(cameraSnapshot.renderViewMatrix,
+                 equals: expectedPose.makeRenderViewMatrix())
+}
+
+@MainActor
 private final class FakePreparedRenderSnapshotSource: PreparedRenderSnapshotProviding {
     var latestSnapshot: PreparedRenderSnapshot?
     var requestedSimulationTimes: [Float] = []
@@ -66,4 +190,33 @@ private func expectMatrix(_ lhs: float4x4,
             #expect(abs(lhs[column][row] - rhs[column][row]) <= tolerance)
         }
     }
+}
+
+private func expectCameraSnapshot(_ lhs: SnapshotProvider.CameraSnapshot,
+                                  equals rhs: SnapshotProvider.CameraSnapshot,
+                                  tolerance: Float = 0.000001) {
+    expectMatrix(lhs.renderViewMatrix,
+                 equals: rhs.renderViewMatrix,
+                 tolerance: tolerance)
+    expectMatrix(lhs.projectionMatrix,
+                 equals: rhs.projectionMatrix,
+                 tolerance: tolerance)
+    expectVector(lhs.sceneOrigin,
+                 equals: rhs.sceneOrigin,
+                 tolerance: tolerance)
+    expectVector(lhs.cameraPosition,
+                 equals: rhs.cameraPosition,
+                 tolerance: tolerance)
+    #expect(lhs.viewportSize == rhs.viewportSize)
+    #expect(lhs.cameraRevision == rhs.cameraRevision)
+    #expect(lhs.cameraDirtyFields == rhs.cameraDirtyFields)
+    #expect(lhs.sceneFrameID == rhs.sceneFrameID)
+}
+
+private func expectVector(_ lhs: SIMD3<Float>,
+                          equals rhs: SIMD3<Float>,
+                          tolerance: Float = 0.000001) {
+    #expect(abs(lhs.x - rhs.x) <= tolerance)
+    #expect(abs(lhs.y - rhs.y) <= tolerance)
+    #expect(abs(lhs.z - rhs.z) <= tolerance)
 }


### PR DESCRIPTION
## Summary
- Make `CameraState` canonical-only with dirty-field tracking and change-detecting transactions.
- Move immutable camera pose derivation and snapshot reuse into `SnapshotProvider`.
- Update follow, navigation, and transfer preview flows to commit canonical camera state only.
- Add coverage for dirty commits, constraint enforcement, and snapshot cache invalidation.

Resolves #301

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -scheme MetalModule -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`