### PR TITLE
Implemented ADR 0003 finalization

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
@@ -4,7 +4,7 @@ import UIKit
 @MainActor
 final class CameraController: NSObject, UIGestureRecognizerDelegate {
 
-    private let cameraCoordniator: CameraCoordinator
+    private let cameraCoordinator: CameraCoordinator
     private let beginManualCameraControl: () -> Void
     private let isTrajectoryModeActive: () -> Bool
 
@@ -12,14 +12,14 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
          beginManualCameraControl: @escaping () -> Void,
          isTrajectoryModeActive: @escaping () -> Bool) {
 
-        cameraCoordniator = cameraCoordinator
+        self.cameraCoordinator = cameraCoordinator
         self.beginManualCameraControl = beginManualCameraControl
         self.isTrajectoryModeActive = isTrajectoryModeActive
         super.init()
     }
 
     func dismantle() {
-        cameraCoordniator.deactivate()
+        cameraCoordinator.deactivate()
     }
 
     // MARK: - Gesture handling
@@ -27,7 +27,7 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
         beginManualCameraControl()
         let translation = gesture.translation(in: gesture.view)
         let velocity = gesture.velocity(in: gesture.view)
-        cameraCoordniator.makeRotation(with: translation, velocity: velocity)
+        cameraCoordinator.makeRotation(with: translation, velocity: velocity)
         gesture.setTranslation(.zero, in: gesture.view)
     }
 
@@ -35,14 +35,14 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
         beginManualCameraControl()
 
         let translation = gesture.translation(in: gesture.view)
-        cameraCoordniator.makeTranslation(with: translation)
+        cameraCoordinator.makeTranslation(with: translation)
         gesture.setTranslation(.zero, in: gesture.view)
     }
 
     @objc func handlePinch(_ gesture: UIPinchGestureRecognizer) {
         beginManualCameraControl()
         let gestureScale = max(Float(gesture.scale), 0.01)
-        cameraCoordniator.makeScale(with: gestureScale, velocity: gesture.velocity)
+        cameraCoordinator.makeScale(with: gestureScale, velocity: gesture.velocity)
         gesture.scale = 1.0
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
@@ -18,10 +18,6 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
         super.init()
     }
 
-    func dismantle() {
-        cameraCoordinator.deactivate()
-    }
-
     // MARK: - Gesture handling
     @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
         beginManualCameraControl()

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -8,7 +8,6 @@
 import CoreFoundation
 import CoreGraphics
 import Foundation
-import QuartzCore
 import simd
 
 /// Routes camera commands to the active camera mode owners.
@@ -38,7 +37,7 @@ final class CameraCoordinator {
     let navigationCameraOwner: NavigationCameraOwner
     let transferPreviewCameraOwner: TransferPreviewCameraOwner
 
-    private var displayLink: CADisplayLink?
+    private var activeCameraMotionRevision = 0
 
     init(cameraState: CameraState,
          snapshotProvider: SnapshotProvider) {
@@ -74,11 +73,9 @@ final class CameraCoordinator {
     }
 
     func activate() {
-        startLoop()
     }
 
     func deactivate() {
-        stopLoop()
     }
 
     func makeTranslation(with value: CGPoint) {
@@ -124,17 +121,23 @@ final class CameraCoordinator {
     }
 
     func beginManualCameraControl() {
+        zoomMode.cancelInertia()
+        orbitMode.cancelInertia()
         followCameraOwner.beginManualCameraControl()
     }
 
-    /// Advances the follow camera when no higher-priority mode currently owns the camera.
+    /// Advances all camera-layer per-frame work for the current render iteration.
     ///
-    /// `isSuppressed` is true while navigation controls the camera or transfer preview is active.
-    /// Pending follow requests are preserved while suppressed and resolve on a later frame.
-    func updateFollowCamera(snapshot: PreparedRenderSnapshot?,
-                            delta: Float,
-                            viewportSize: CGSize,
-                            isSuppressed: Bool) {
+    /// Route playback and transfer-orbit geometry remain owned by their controllers. This entry point
+    /// owns camera priority for manual inertia and follow behavior before `SnapshotProvider` derives
+    /// immutable matrices.
+    func updateFrameCamera(snapshot: PreparedRenderSnapshot?,
+                           delta: Float,
+                           viewportSize: CGSize,
+                           modeState: CameraFrameModeState) {
+        updateManualCameraInertia(delta: delta)
+
+        let isSuppressed = modeState.navigationControlsCamera || modeState.transferPreviewActive
         followCameraOwner.update(snapshot: snapshot,
                                  delta: delta,
                                  viewportSize: viewportSize,
@@ -142,12 +145,31 @@ final class CameraCoordinator {
         if !isSuppressed {
             refreshCamera(snapshot: snapshot)
         }
+
+        if hasActiveCameraMotion(modeState: modeState) {
+            activeCameraMotionRevision += 1
+        }
     }
 
     func followProjectionParameters(snapshot: PreparedRenderSnapshot?,
                                     baseProjection: CameraProjectionParameters) -> CameraProjectionParameters {
         followCameraOwner.projectionParameters(snapshot: snapshot,
                                                baseProjection: baseProjection)
+    }
+
+    func makeSnapshotDependencies(snapshot: PreparedRenderSnapshot?,
+                                  viewportSize: CGSize,
+                                  projection: CameraProjectionParameters,
+                                  modeState: CameraFrameModeState) -> CameraSnapshotDependencies {
+        CameraSnapshotDependencies(
+            followedObject: followCameraOwner.snapshotDependency(snapshot: snapshot),
+            navigation: modeState.navigation,
+            transfer: modeState.transfer,
+            activeCameraMotionRevision: activeCameraMotionRevision,
+            sceneFrameID: snapshot?.frameID,
+            viewportSize: viewportSize,
+            projection: projection
+        )
     }
 
     /// Rebuilds derived camera values after mode transactions or gesture inertia.
@@ -161,7 +183,7 @@ final class CameraCoordinator {
         )
     }
 
-    private func update(delta: Float) {
+    private func updateManualCameraInertia(delta: Float) {
         commitManualCameraTransaction(
             zoomMode.update(delta: delta,
                             currentDistance: cameraState.cameraDistance)
@@ -176,27 +198,15 @@ final class CameraCoordinator {
         }
     }
 
+    private func hasActiveCameraMotion(modeState: CameraFrameModeState) -> Bool {
+        zoomMode.hasActiveInertia ||
+        orbitMode.hasActiveInertia ||
+        followCameraOwner.hasActiveTransition ||
+        modeState.hasActiveExternalCameraMotion
+    }
+
     private func commitManualCameraTransaction(_ transaction: CameraState.Transaction?) {
         guard let transaction else { return }
         cameraState.commit(transaction)
-    }
-
-    // MARK: Update loop
-
-    private func startLoop() {
-        guard displayLink == nil else { return }
-
-        displayLink = CADisplayLink(target: self, selector: #selector(step(_:)))
-        displayLink?.add(to: .main, forMode: .common)
-    }
-
-    private func stopLoop() {
-        displayLink?.invalidate()
-        displayLink = nil
-    }
-
-    @objc private func step(_ link: CADisplayLink) {
-        let delta = Float(link.duration)
-        update(delta: delta)
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -39,19 +39,6 @@ final class CameraCoordinator {
 
     private var activeCameraMotionRevision = 0
 
-    init(cameraState: CameraState,
-         snapshotProvider: SnapshotProvider) {
-        self.cameraState = cameraState
-        self.snapshotProvider = snapshotProvider
-        zoomMode = .init()
-        orbitMode = .init()
-        trajectoryMode = .init()
-        followCameraOwner = .init(cameraState: cameraState,
-                                  snapshotProvider: snapshotProvider)
-        navigationCameraOwner = .init(cameraState: cameraState)
-        transferPreviewCameraOwner = .init(cameraState: cameraState)
-    }
-
     var currentCameraTransitionFrame: CameraTransition.Frame {
         cameraState.currentCameraTransitionFrame
     }
@@ -72,10 +59,17 @@ final class CameraCoordinator {
         cameraState.cameraDistance
     }
 
-    func activate() {
-    }
-
-    func deactivate() {
+    init(cameraState: CameraState,
+         snapshotProvider: SnapshotProvider) {
+        self.cameraState = cameraState
+        self.snapshotProvider = snapshotProvider
+        zoomMode = .init()
+        orbitMode = .init()
+        trajectoryMode = .init()
+        followCameraOwner = .init(cameraState: cameraState,
+                                  snapshotProvider: snapshotProvider)
+        navigationCameraOwner = .init(cameraState: cameraState)
+        transferPreviewCameraOwner = .init(cameraState: cameraState)
     }
 
     func makeTranslation(with value: CGPoint) {

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraPose.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraPose.swift
@@ -1,0 +1,39 @@
+//
+//  CameraPose.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+import simd
+
+struct CameraPose: Equatable {
+    let target: SIMD3<Float>
+    let distance: Float
+    let orientation: simd_quatf
+
+    var offset: SIMD3<Float> {
+        orientation.act(SIMD3<Float>(0, 0, distance))
+    }
+
+    var position: SIMD3<Float> {
+        target + offset
+    }
+
+    var upVector: SIMD3<Float> {
+        orientation.act(SIMD3<Float>(0, 1, 0))
+    }
+
+    var transitionFrame: CameraTransition.Frame {
+        .init(target: target,
+              distance: distance)
+    }
+
+    func makeRenderViewMatrix() -> float4x4 {
+        float4x4.lookAt(
+            eye: offset,
+            target: .zero,
+            upVector: upVector
+        )
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraState.swift
@@ -7,37 +7,6 @@
 
 import simd
 
-struct CameraPose: Equatable {
-    let target: SIMD3<Float>
-    let distance: Float
-    let orientation: simd_quatf
-
-    var offset: SIMD3<Float> {
-        orientation.act(SIMD3<Float>(0, 0, distance))
-    }
-
-    var position: SIMD3<Float> {
-        target + offset
-    }
-
-    var upVector: SIMD3<Float> {
-        orientation.act(SIMD3<Float>(0, 1, 0))
-    }
-
-    var transitionFrame: CameraTransition.Frame {
-        .init(target: target,
-              distance: distance)
-    }
-
-    func makeRenderViewMatrix() -> float4x4 {
-        float4x4.lookAt(
-            eye: offset,
-            target: .zero,
-            upVector: upVector
-        )
-    }
-}
-
 /// Owns canonical camera variables and camera revision metadata
 final class CameraState {
     struct DirtyFields: OptionSet, Equatable {
@@ -67,9 +36,9 @@ final class CameraState {
     let minDistance: Float = 0.001
     private let maxDistance: Float = 10000.0
 
-    private(set) var cameraDistance: Float = 3 // !
-    private(set) var cameraTarget = SIMD3<Float>(0, 0, 0) // !
-    private(set) var cameraOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0)) // !
+    private(set) var cameraDistance: Float = 3
+    private(set) var cameraTarget = SIMD3<Float>(0, 0, 0)
+    private(set) var cameraOrientation = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
     private(set) var revision = 0
     private(set) var lastDirtyFields: DirtyFields = []
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/FollowCameraOwner.swift
@@ -38,6 +38,10 @@ final class FollowCameraOwner {
         self.followMode = followMode
     }
 
+    var hasActiveTransition: Bool {
+        cameraTransition != nil
+    }
+
     func followPlanet(named name: String,
                       viewportSize: CGSize) {
         followingPlanetName = name
@@ -102,6 +106,19 @@ final class FollowCameraOwner {
                                         snapshot: snapshot,
                                         cameraDistance: cameraState.cameraDistance,
                                         baseProjection: baseProjection)
+    }
+
+    func snapshotDependency(snapshot: PreparedRenderSnapshot?) -> CameraFollowSnapshotDependency? {
+        guard let planetName = pendingFollowPlanetName ?? followingPlanetName else {
+            return nil
+        }
+
+        return CameraFollowSnapshotDependency(
+            planetName: planetName,
+            worldPosition: snapshot?.worldPosition(ofPlanetNamed: planetName),
+            framingRadius: snapshot?.framingRadius(ofPlanetNamed: planetName),
+            hasActiveTransition: hasActiveTransition
+        )
     }
 
     private func startFollowAnimation(named name: String,

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/OrbitCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/OrbitCameraMode.swift
@@ -17,6 +17,10 @@ final class OrbitCameraMode {
     private var pitchVelocity: Float = 0
     private let damping: Float = 0.9
 
+    var hasActiveInertia: Bool {
+        yawVelocity != 0 || pitchVelocity != 0
+    }
+
     func makeOrbitTransaction(horizontal horizontalAngle: Float,
                               vertical verticalAngle: Float,
                               cameraOrientation currentOrientation: simd_quatf) -> CameraState.Transaction {
@@ -36,9 +40,14 @@ final class OrbitCameraMode {
         pitchVelocity = Float(velocity.y) * orbitSpeed * 0.1
     }
 
+    func cancelInertia() {
+        yawVelocity = 0
+        pitchVelocity = 0
+    }
+
     func update(delta: Float,
                 cameraOrientation: simd_quatf) -> CameraState.Transaction? {
-        guard yawVelocity != 0 || pitchVelocity != 0 else {
+        guard hasActiveInertia else {
             return nil
         }
         let transaction = makeOrbitTransaction(horizontal: yawVelocity * delta,

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/ZoomCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/ZoomCameraMode.swift
@@ -14,6 +14,10 @@ final class ZoomCameraMode {
     private let zoomSpeed: Float = 1.0
     private let damping: Float = 0.9
 
+    var hasActiveInertia: Bool {
+        zoomVelocity != 0
+    }
+
     func makeZoomTransaction(value: Float,
                              currentDistance: Float) -> CameraState.Transaction {
         let zoomFactor = pow(value, zoomSpeed)
@@ -27,9 +31,13 @@ final class ZoomCameraMode {
         zoomVelocity = -Float(velocity) * currentDistance * 0.15
     }
 
+    func cancelInertia() {
+        zoomVelocity = 0
+    }
+
     func update(delta: Float,
                 currentDistance: Float) -> CameraState.Transaction? {
-        guard zoomVelocity != 0 else {
+        guard hasActiveInertia else {
             return nil
         }
         let cameraDistance = currentDistance + zoomVelocity * delta

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider.swift
@@ -6,11 +6,55 @@
 //
 
 import CoreGraphics
+import Foundation
 import simd
 
 struct CameraProjectionParameters: Equatable {
     let nearPlane: Float
     let farPlane: Float
+}
+
+struct CameraFollowSnapshotDependency: Equatable {
+    let planetName: String
+    let worldPosition: SIMD3<Float>?
+    let framingRadius: Float?
+    let hasActiveTransition: Bool
+}
+
+struct CameraNavigationSnapshotDependency: Equatable {
+    let routeID: UUID?
+    let destinationName: String?
+    let progress: Float
+    let state: NavigationRouteState
+    let hasActiveTransition: Bool
+    let arrivalProgress: Float
+}
+
+struct CameraTransferSnapshotDependency: Equatable {
+    let destinationName: String?
+    let hasActiveTransition: Bool
+}
+
+struct CameraFrameModeState: Equatable {
+    let navigationControlsCamera: Bool
+    let navigation: CameraNavigationSnapshotDependency?
+    let transferPreviewActive: Bool
+    let transfer: CameraTransferSnapshotDependency?
+
+    var hasActiveExternalCameraMotion: Bool {
+        navigation?.hasActiveTransition == true ||
+        transfer?.hasActiveTransition == true
+    }
+}
+
+struct CameraSnapshotDependencies: Equatable {
+    let followedObject: CameraFollowSnapshotDependency?
+    let navigation: CameraNavigationSnapshotDependency?
+    let transfer: CameraTransferSnapshotDependency?
+    let activeCameraMotionRevision: Int
+    let sceneFrameID: UInt64?
+    let viewportSize: CGSize
+    let projection: CameraProjectionParameters
 }
 
 /// Reads committed camera state, scene snapshots, viewport data, and explicit projection requirements.
@@ -31,20 +75,20 @@ final class SnapshotProvider {
     private struct CameraSnapshotDependencyKey: Equatable {
         let cameraRevision: Int
         let cameraDirtyFields: CameraState.DirtyFields
-        let sceneFrameID: UInt64?
-        let viewportSize: CGSize
-        let projection: CameraProjectionParameters
+        let dependencies: CameraSnapshotDependencies
     }
 
     struct CameraSnapshot {
         let renderViewMatrix: float4x4
         let projectionMatrix: float4x4
         let sceneOrigin: SIMD3<Float>
-        let cameraPosition: SIMD3<Float>
+        let cameraOffset: SIMD3<Float>
+        let cameraWorldPosition: SIMD3<Float>
         let viewportSize: CGSize
         let cameraRevision: Int
         let cameraDirtyFields: CameraState.DirtyFields
         let sceneFrameID: UInt64?
+        let dependencies: CameraSnapshotDependencies
     }
 
     init(cameraState: CameraState,
@@ -62,15 +106,11 @@ final class SnapshotProvider {
         snapshotSource.requestPreparation(simulationTime: simulationTime)
     }
 
-    func makeCameraSnapshot(viewportSize: CGSize,
-                            projection: CameraProjectionParameters) -> CameraSnapshot {
-        let sceneFrameID = latestSnapshot?.frameID
+    func makeCameraSnapshot(dependencies: CameraSnapshotDependencies) -> CameraSnapshot {
         let dependencyKey = CameraSnapshotDependencyKey(
             cameraRevision: cameraState.revision,
             cameraDirtyFields: cameraState.lastDirtyFields,
-            sceneFrameID: sceneFrameID,
-            viewportSize: viewportSize,
-            projection: projection
+            dependencies: dependencies
         )
         if dependencyKey == cachedDependencyKey,
            let cachedCameraSnapshot {
@@ -78,22 +118,25 @@ final class SnapshotProvider {
         }
 
         let cameraPose = cameraState.pose
-        let aspect = Float(viewportSize.width / max(viewportSize.height, 1))
+        let aspect = Float(dependencies.viewportSize.width / max(dependencies.viewportSize.height, 1))
         let projectionMatrix = float4x4.perspective(
             fov: CameraFit.verticalFieldOfView,
             aspect: aspect,
-            near: projection.nearPlane,
-            far: max(projection.farPlane, projection.nearPlane + CameraFit.minimumNearPlane)
+            near: dependencies.projection.nearPlane,
+            far: max(dependencies.projection.farPlane,
+                     dependencies.projection.nearPlane + CameraFit.minimumNearPlane)
         )
 
         let cameraSnapshot = CameraSnapshot(renderViewMatrix: cameraPose.makeRenderViewMatrix(),
                                             projectionMatrix: projectionMatrix,
                                             sceneOrigin: cameraPose.target,
-                                            cameraPosition: cameraPose.offset,
-                                            viewportSize: viewportSize,
+                                            cameraOffset: cameraPose.offset,
+                                            cameraWorldPosition: cameraPose.position,
+                                            viewportSize: dependencies.viewportSize,
                                             cameraRevision: cameraState.revision,
                                             cameraDirtyFields: cameraState.lastDirtyFields,
-                                            sceneFrameID: sceneFrameID)
+                                            sceneFrameID: dependencies.sceneFrameID,
+                                            dependencies: dependencies)
         cachedDependencyKey = dependencyKey
         cachedCameraSnapshot = cameraSnapshot
         return cameraSnapshot

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraFollowSnapshotDependency.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraFollowSnapshotDependency.swift
@@ -1,0 +1,13 @@
+//
+//  CameraFollowSnapshotDependency.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+struct CameraFollowSnapshotDependency: Equatable {
+    let planetName: String
+    let worldPosition: SIMD3<Float>?
+    let framingRadius: Float?
+    let hasActiveTransition: Bool
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraFrameModeState.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraFrameModeState.swift
@@ -1,0 +1,18 @@
+//
+//  CameraFrameModeState.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+struct CameraFrameModeState: Equatable {
+    let navigationControlsCamera: Bool
+    let navigation: CameraNavigationSnapshotDependency?
+    let transferPreviewActive: Bool
+    let transfer: CameraTransferSnapshotDependency?
+
+    var hasActiveExternalCameraMotion: Bool {
+        navigation?.hasActiveTransition == true ||
+        transfer?.hasActiveTransition == true
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraNavigationSnapshotDependency.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraNavigationSnapshotDependency.swift
@@ -1,0 +1,17 @@
+//
+//  CameraNavigationSnapshotDependency.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+import Foundation
+
+struct CameraNavigationSnapshotDependency: Equatable {
+    let routeID: UUID?
+    let destinationName: String?
+    let progress: Float
+    let state: NavigationRouteState
+    let hasActiveTransition: Bool
+    let arrivalProgress: Float
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraProjectionParameters.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraProjectionParameters.swift
@@ -1,0 +1,11 @@
+//
+//  CameraProjectionParameters.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+struct CameraProjectionParameters: Equatable {
+    let nearPlane: Float
+    let farPlane: Float
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraSnapshotDependencies.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraSnapshotDependencies.swift
@@ -1,0 +1,18 @@
+//
+//  CameraSnapshotDependencies.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+import CoreFoundation
+
+struct CameraSnapshotDependencies: Equatable {
+    let followedObject: CameraFollowSnapshotDependency?
+    let navigation: CameraNavigationSnapshotDependency?
+    let transfer: CameraTransferSnapshotDependency?
+    let activeCameraMotionRevision: Int
+    let sceneFrameID: UInt64?
+    let viewportSize: CGSize
+    let projection: CameraProjectionParameters
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraTransferSnapshotDependency.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/Entities/CameraTransferSnapshotDependency.swift
@@ -1,0 +1,11 @@
+//
+//  CameraTransferSnapshotDependency.swift
+//  MetalModule
+//
+//  Created by max on 31.05.2026.
+//
+
+struct CameraTransferSnapshotDependency: Equatable {
+    let destinationName: String?
+    let hasActiveTransition: Bool
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/SnapshotProvider.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SnapshotProvider/SnapshotProvider.swift
@@ -9,54 +9,6 @@ import CoreGraphics
 import Foundation
 import simd
 
-struct CameraProjectionParameters: Equatable {
-    let nearPlane: Float
-    let farPlane: Float
-}
-
-struct CameraFollowSnapshotDependency: Equatable {
-    let planetName: String
-    let worldPosition: SIMD3<Float>?
-    let framingRadius: Float?
-    let hasActiveTransition: Bool
-}
-
-struct CameraNavigationSnapshotDependency: Equatable {
-    let routeID: UUID?
-    let destinationName: String?
-    let progress: Float
-    let state: NavigationRouteState
-    let hasActiveTransition: Bool
-    let arrivalProgress: Float
-}
-
-struct CameraTransferSnapshotDependency: Equatable {
-    let destinationName: String?
-    let hasActiveTransition: Bool
-}
-
-struct CameraFrameModeState: Equatable {
-    let navigationControlsCamera: Bool
-    let navigation: CameraNavigationSnapshotDependency?
-    let transferPreviewActive: Bool
-    let transfer: CameraTransferSnapshotDependency?
-
-    var hasActiveExternalCameraMotion: Bool {
-        navigation?.hasActiveTransition == true ||
-        transfer?.hasActiveTransition == true
-    }
-}
-
-struct CameraSnapshotDependencies: Equatable {
-    let followedObject: CameraFollowSnapshotDependency?
-    let navigation: CameraNavigationSnapshotDependency?
-    let transfer: CameraTransferSnapshotDependency?
-    let activeCameraMotionRevision: Int
-    let sceneFrameID: UInt64?
-    let viewportSize: CGSize
-    let projection: CameraProjectionParameters
-}
-
 /// Reads committed camera state, scene snapshots, viewport data, and explicit projection requirements.
 /// It produces immutable camera snapshots containing render-ready matrices and derived camera values.
 @MainActor

--- a/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources.swift
@@ -89,7 +89,6 @@ public final class MetalModuleResources {
             self.cameraCoordinator.followNavigationDestination(named: name,
                                                                viewportSize: renderer?.metalView.bounds.size ?? .zero)
         }
-        cameraCoordinator.activate()
         return renderer
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/Navigation/NavigationController.swift
@@ -87,6 +87,30 @@ final class NavigationController {
         isNavigationActive || cameraTransition != nil
     }
 
+    var cameraSnapshotDependency: CameraNavigationSnapshotDependency? {
+        let routeSnapshot = navigationSnapshot
+        let activeRoute = navigationRouteCoordinator.activeRouteForRendering
+
+        guard activeRoute != nil ||
+              routeSnapshot.routeID != nil ||
+              pendingNavigationDestinationName != nil ||
+              cameraTransition != nil else {
+            return nil
+        }
+
+        return CameraNavigationSnapshotDependency(
+            routeID: activeRoute?.id ?? routeSnapshot.routeID,
+            destinationName: activeRoute?.destinationName ??
+            routeSnapshot.destinationName ??
+            pendingNavigationDestinationName,
+            progress: navigationRouteCoordinator.renderProgress,
+            state: navigationRouteCoordinator.state,
+            hasActiveTransition: cameraTransition != nil ||
+            (navigationArrivalRouteID != nil && navigationArrivalProgress < 1),
+            arrivalProgress: navigationArrivalProgress
+        )
+    }
+
     init(snapshotProvider: SnapshotProvider,
          cameraCoordinator: any NavigationCameraCoordinating,
          planets: [Planet],

--- a/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
@@ -36,6 +36,19 @@ final class TransferOrbitController {
         activeTransferOrbit != nil
     }
 
+    var cameraSnapshotDependency: CameraTransferSnapshotDependency? {
+        guard activeDestinationName != nil ||
+              pendingDestinationName != nil ||
+              cameraTransition != nil else {
+            return nil
+        }
+
+        return CameraTransferSnapshotDependency(
+            destinationName: activeDestinationName ?? pendingDestinationName,
+            hasActiveTransition: cameraTransition != nil
+        )
+    }
+
     var renderState: TransferOrbitRenderState {
         TransferOrbitRenderState(transferOrbit: activeTransferOrbit)
     }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+CameraFrame.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+CameraFrame.swift
@@ -1,0 +1,40 @@
+//
+//  MetalRenderer+CameraFrame.swift
+//  MetalModule
+//
+//  Created by Codex on 31.05.2026.
+//
+
+extension MetalRenderer {
+    func makeCameraFrameModeState() -> CameraFrameModeState {
+        CameraFrameModeState(
+            navigationControlsCamera: navigationController.controlsCamera,
+            navigation: navigationController.cameraSnapshotDependency,
+            transferPreviewActive: transferOrbitController.isTransferPreviewActive,
+            transfer: transferOrbitController.cameraSnapshotDependency
+        )
+    }
+
+    func makeCameraProjection(snapshot: PreparedRenderSnapshot?) -> CameraProjectionParameters {
+        let baseProjection = CameraProjectionParameters(nearPlane: CameraFit.defaultNearPlane,
+                                                        farPlane: farPlaneDistance())
+        let followProjection = cameraCoordinator.followProjectionParameters(snapshot: snapshot,
+                                                                            baseProjection: baseProjection)
+        let transferProjection = transferOrbitController.projectionParameters(snapshot: snapshot,
+                                                                             baseProjection: followProjection)
+        return navigationController.projectionParameters(snapshot: snapshot,
+                                                        baseProjection: transferProjection)
+    }
+
+    func makeCameraSnapshot(snapshot: PreparedRenderSnapshot?,
+                            projection: CameraProjectionParameters,
+                            modeState: CameraFrameModeState) -> SnapshotProvider.CameraSnapshot {
+        let dependencies = cameraCoordinator.makeSnapshotDependencies(
+            snapshot: snapshot,
+            viewportSize: metalView.bounds.size,
+            projection: projection,
+            modeState: modeState
+        )
+        return snapshotProvider.makeCameraSnapshot(dependencies: dependencies)
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
@@ -52,7 +52,7 @@ extension MetalRenderer {
                                                       renderEncoder: renderEncoder,
                                                       viewMatrix: renderViewMatrix,
                                                       projectionMatrix: state.cameraSnapshot.projectionMatrix,
-                                                      cameraPosition: state.cameraSnapshot.cameraPosition,
+                                                      cameraOffset: state.cameraSnapshot.cameraOffset,
                                                       sceneOrigin: renderOrigin,
                                                       viewportSize: state.cameraSnapshot.viewportSize,
                                                       cartoonShaderIntensity: min(max(cartoonShaderIntensity, 0), 1))

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -159,8 +159,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
             return
         }
 
-        // Advance simulation time and update camera before rendering so that
-        // the view matches the planets' latest positions within the same frame.
+        // Advance simulation time and publish route/transfer state before camera snapshot derivation.
         let delta = planetsRenderer.advanceTime()
         snapshotProvider.requestPreparation(simulationTime: planetsRenderer.currentTime)
         let snapshot = snapshotProvider.latestSnapshot
@@ -169,22 +168,15 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
                                        delta: delta)
         navigationController.update(snapshot: snapshot,
                                     delta: delta)
-        let suppressFollowCamera = navigationController.controlsCamera ||
-        transferOrbitController.isTransferPreviewActive
-        cameraCoordinator.updateFollowCamera(snapshot: snapshot,
-                                             delta: delta,
-                                             viewportSize: metalView.bounds.size,
-                                             isSuppressed: suppressFollowCamera)
-        let baseProjection = CameraProjectionParameters(nearPlane: CameraFit.defaultNearPlane,
-                                                        farPlane: farPlaneDistance())
-        let followProjection = cameraCoordinator.followProjectionParameters(snapshot: snapshot,
-                                                                            baseProjection: baseProjection)
-        let transferProjection = transferOrbitController.projectionParameters(snapshot: snapshot,
-                                                                             baseProjection: followProjection)
-        let projection = navigationController.projectionParameters(snapshot: snapshot,
-                                                                  baseProjection: transferProjection)
-        let cameraSnapshot = snapshotProvider.makeCameraSnapshot(viewportSize: metalView.bounds.size,
-                                                                 projection: projection)
+        let modeState = makeCameraFrameModeState()
+        cameraCoordinator.updateFrameCamera(snapshot: snapshot,
+                                            delta: delta,
+                                            viewportSize: metalView.bounds.size,
+                                            modeState: modeState)
+        let projection = makeCameraProjection(snapshot: snapshot)
+        let cameraSnapshot = makeCameraSnapshot(snapshot: snapshot,
+                                                projection: projection,
+                                                modeState: modeState)
 
         do {
             try drawFirstPass(msaaColorTexture: msaaColorTexture,
@@ -206,7 +198,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         }
     }
 
-    private func farPlaneDistance() -> Float {
+    func farPlaneDistance() -> Float {
         return CameraFit.defaultFarPlane
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
@@ -13,7 +13,7 @@ struct PlanetRenderConfiguration {
     let renderEncoder: MTLRenderCommandEncoder
     let viewMatrix: float4x4
     let projectionMatrix: float4x4
-    let cameraPosition: SIMD3<Float>
+    let cameraOffset: SIMD3<Float>
     let sceneOrigin: SIMD3<Float>
     let viewportSize: CGSize
     let cartoonShaderIntensity: Float

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+PlanetsRendererProtocol.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+PlanetsRendererProtocol.swift
@@ -33,7 +33,7 @@ extension PlanetsRenderer: PlanetsRendererProtocol {
                          configuration: configuration)
         }
 
-        let cameraWorldPosition = configuration.sceneOrigin + configuration.cameraPosition
+        let cameraWorldPosition = configuration.sceneOrigin + configuration.cameraOffset
         let transparentPlanets = snapshot.planets
             .filter { planet in
                 hasTransparentSubmesh(in: planet)

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+Render.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+Render.swift
@@ -47,7 +47,7 @@ extension PlanetsRenderer {
         // Set buffers
         renderEncoder.setFragmentSamplerState(samplerState, index: 0)
         var fragmentUniforms = FragmentUniforms(
-            cameraPosition: configuration.cameraPosition,
+            cameraPosition: configuration.cameraOffset,
             lightPosition: -configuration.sceneOrigin,
             cartoonShaderIntensity: min(max(configuration.cartoonShaderIntensity, 0), 1)
         )
@@ -57,7 +57,7 @@ extension PlanetsRenderer {
 
         let renderSubmeshes = submeshes(for: planet,
                                         renderPass: renderPass,
-                                        cameraPosition: configuration.cameraPosition,
+                                        cameraPosition: configuration.cameraOffset,
                                         sceneOrigin: configuration.sceneOrigin)
 
         render(renderSubmeshes: renderSubmeshes,

--- a/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
+++ b/Modules/MetalModule/Sources/MetalModule/UniverseView.swift
@@ -100,7 +100,6 @@ public struct UniverseView: UIViewRepresentable {
     }
 
     public static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
-        coordinator.cameraController?.dismantle()
         coordinator.renderer?.dismantle()
         coordinator.cameraController = nil
         coordinator.renderer = nil

--- a/Modules/MetalModule/Tests/MetalModuleTests/SnapshotProviderTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/SnapshotProviderTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import simd
 import Testing
 @testable import MetalModule
@@ -33,8 +34,10 @@ import Testing
     let projection = CameraProjectionParameters(nearPlane: 0.25,
                                                 farPlane: 42)
 
-    let cameraSnapshot = provider.makeCameraSnapshot(viewportSize: viewportSize,
-                                                     projection: projection)
+    let cameraSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(viewportSize: viewportSize,
+                                       projection: projection)
+    )
     let expectedProjection = float4x4.perspective(fov: CameraFit.verticalFieldOfView,
                                                   aspect: 2,
                                                   near: projection.nearPlane,
@@ -57,10 +60,11 @@ import Testing
     let projection = CameraProjectionParameters(nearPlane: 0.1,
                                                 farPlane: 100)
 
-    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                    projection: projection)
-    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                     projection: projection)
+    let dependencies = makeDependencies(sceneFrameID: source.latestSnapshot?.frameID,
+                                        viewportSize: CGSize(width: 200, height: 100),
+                                        projection: projection)
+    let firstSnapshot = provider.makeCameraSnapshot(dependencies: dependencies)
+    let secondSnapshot = provider.makeCameraSnapshot(dependencies: dependencies)
 
     expectCameraSnapshot(secondSnapshot,
                          equals: firstSnapshot)
@@ -78,16 +82,17 @@ import Testing
                                     snapshotSource: source)
     let projection = CameraProjectionParameters(nearPlane: 0.1,
                                                 farPlane: 100)
-    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                    projection: projection)
+    let dependencies = makeDependencies(sceneFrameID: source.latestSnapshot?.frameID,
+                                        viewportSize: CGSize(width: 200, height: 100),
+                                        projection: projection)
+    let firstSnapshot = provider.makeCameraSnapshot(dependencies: dependencies)
 
     cameraState.commit(CameraState.Transaction(cameraDistance: 4))
-    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                     projection: projection)
+    let secondSnapshot = provider.makeCameraSnapshot(dependencies: dependencies)
 
     #expect(secondSnapshot.cameraRevision == firstSnapshot.cameraRevision + 1)
     #expect(secondSnapshot.cameraDirtyFields == [.distance])
-    expectVector(secondSnapshot.cameraPosition,
+    expectVector(secondSnapshot.cameraOffset,
                  equals: SIMD3<Float>(0, 0, 4))
 }
 
@@ -101,14 +106,20 @@ import Testing
     let provider = SnapshotProvider(snapshotSource: source)
     let projection = CameraProjectionParameters(nearPlane: 0.1,
                                                 farPlane: 100)
-    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                    projection: projection)
+    let firstSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(sceneFrameID: source.latestSnapshot?.frameID,
+                                       viewportSize: CGSize(width: 200, height: 100),
+                                       projection: projection)
+    )
 
     source.latestSnapshot = PreparedRenderSnapshot(frameID: 2,
                                                    simulationTime: 1,
                                                    planets: [])
-    let secondSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                     projection: projection)
+    let secondSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(sceneFrameID: source.latestSnapshot?.frameID,
+                                       viewportSize: CGSize(width: 200, height: 100),
+                                       projection: projection)
+    )
 
     #expect(firstSnapshot.sceneFrameID == 1)
     #expect(secondSnapshot.sceneFrameID == 2)
@@ -119,26 +130,112 @@ import Testing
     let provider = SnapshotProvider(snapshotSource: FakePreparedRenderSnapshotSource())
     let projection = CameraProjectionParameters(nearPlane: 0.1,
                                                 farPlane: 100)
-    let firstSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 200, height: 100),
-                                                    projection: projection)
+    let firstSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(viewportSize: CGSize(width: 200, height: 100),
+                                       projection: projection)
+    )
 
-    let viewportSnapshot = provider.makeCameraSnapshot(viewportSize: CGSize(width: 100, height: 100),
-                                                       projection: projection)
+    let viewportSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(viewportSize: CGSize(width: 100, height: 100),
+                                       projection: projection)
+    )
     let nearPlaneSnapshot = provider.makeCameraSnapshot(
-        viewportSize: CGSize(width: 100, height: 100),
-        projection: CameraProjectionParameters(nearPlane: 0.2,
-                                               farPlane: 100)
+        dependencies: makeDependencies(viewportSize: CGSize(width: 100, height: 100),
+                                       projection: CameraProjectionParameters(nearPlane: 0.2,
+                                                                              farPlane: 100))
     )
     let farPlaneSnapshot = provider.makeCameraSnapshot(
-        viewportSize: CGSize(width: 100, height: 100),
-        projection: CameraProjectionParameters(nearPlane: 0.2,
-                                               farPlane: 200)
+        dependencies: makeDependencies(viewportSize: CGSize(width: 100, height: 100),
+                                       projection: CameraProjectionParameters(nearPlane: 0.2,
+                                                                              farPlane: 200))
     )
 
     #expect(viewportSnapshot.viewportSize == CGSize(width: 100, height: 100))
     #expect(viewportSnapshot.projectionMatrix[0][0] != firstSnapshot.projectionMatrix[0][0])
     #expect(nearPlaneSnapshot.projectionMatrix[2][2] != viewportSnapshot.projectionMatrix[2][2])
     #expect(farPlaneSnapshot.projectionMatrix[2][2] != nearPlaneSnapshot.projectionMatrix[2][2])
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenFollowedObjectSignatureChanges() {
+    let provider = SnapshotProvider(snapshotSource: FakePreparedRenderSnapshotSource())
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+    let firstDependency = CameraFollowSnapshotDependency(
+        planetName: "Mars",
+        worldPosition: SIMD3<Float>(1, 0, 0),
+        framingRadius: 0.1,
+        hasActiveTransition: false
+    )
+    let secondDependency = CameraFollowSnapshotDependency(
+        planetName: "Mars",
+        worldPosition: SIMD3<Float>(2, 0, 0),
+        framingRadius: 0.1,
+        hasActiveTransition: false
+    )
+
+    let firstSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(followedObject: firstDependency,
+                                       projection: projection)
+    )
+    let secondSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(followedObject: secondDependency,
+                                       projection: projection)
+    )
+
+    #expect(firstSnapshot.dependencies.followedObject == firstDependency)
+    #expect(secondSnapshot.dependencies.followedObject == secondDependency)
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenNavigationRouteChanges() {
+    let provider = SnapshotProvider(snapshotSource: FakePreparedRenderSnapshotSource())
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+    let routeID = UUID()
+    let firstNavigation = CameraNavigationSnapshotDependency(routeID: routeID,
+                                                            destinationName: "Mars",
+                                                            progress: 0.1,
+                                                            state: .running,
+                                                            hasActiveTransition: false,
+                                                            arrivalProgress: 1)
+    let secondNavigation = CameraNavigationSnapshotDependency(routeID: routeID,
+                                                             destinationName: "Mars",
+                                                             progress: 0.2,
+                                                             state: .running,
+                                                             hasActiveTransition: false,
+                                                             arrivalProgress: 1)
+
+    let firstSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(navigation: firstNavigation,
+                                       projection: projection)
+    )
+    let secondSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(navigation: secondNavigation,
+                                       projection: projection)
+    )
+
+    #expect(firstSnapshot.dependencies.navigation == firstNavigation)
+    #expect(secondSnapshot.dependencies.navigation == secondNavigation)
+}
+
+@MainActor
+@Test func snapshotProviderInvalidatesCacheWhenActiveMotionRevisionChanges() {
+    let provider = SnapshotProvider(snapshotSource: FakePreparedRenderSnapshotSource())
+    let projection = CameraProjectionParameters(nearPlane: 0.1,
+                                                farPlane: 100)
+
+    let firstSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(activeCameraMotionRevision: 1,
+                                       projection: projection)
+    )
+    let secondSnapshot = provider.makeCameraSnapshot(
+        dependencies: makeDependencies(activeCameraMotionRevision: 2,
+                                       projection: projection)
+    )
+
+    #expect(firstSnapshot.dependencies.activeCameraMotionRevision == 1)
+    #expect(secondSnapshot.dependencies.activeCameraMotionRevision == 2)
 }
 
 @MainActor
@@ -154,16 +251,18 @@ import Testing
                                                cameraOrientation: orientation))
 
     let cameraSnapshot = provider.makeCameraSnapshot(
-        viewportSize: CGSize(width: 200, height: 100),
-        projection: CameraProjectionParameters(nearPlane: 0.1,
-                                               farPlane: 100)
+        dependencies: makeDependencies(viewportSize: CGSize(width: 200, height: 100),
+                                       projection: CameraProjectionParameters(nearPlane: 0.1,
+                                                                              farPlane: 100))
     )
     let expectedPose = cameraState.pose
 
     expectVector(cameraSnapshot.sceneOrigin,
                  equals: expectedPose.target)
-    expectVector(cameraSnapshot.cameraPosition,
+    expectVector(cameraSnapshot.cameraOffset,
                  equals: expectedPose.offset)
+    expectVector(cameraSnapshot.cameraWorldPosition,
+                 equals: expectedPose.position)
     expectMatrix(cameraSnapshot.renderViewMatrix,
                  equals: expectedPose.makeRenderViewMatrix())
 }
@@ -204,13 +303,33 @@ private func expectCameraSnapshot(_ lhs: SnapshotProvider.CameraSnapshot,
     expectVector(lhs.sceneOrigin,
                  equals: rhs.sceneOrigin,
                  tolerance: tolerance)
-    expectVector(lhs.cameraPosition,
-                 equals: rhs.cameraPosition,
+    expectVector(lhs.cameraOffset,
+                 equals: rhs.cameraOffset,
+                 tolerance: tolerance)
+    expectVector(lhs.cameraWorldPosition,
+                 equals: rhs.cameraWorldPosition,
                  tolerance: tolerance)
     #expect(lhs.viewportSize == rhs.viewportSize)
     #expect(lhs.cameraRevision == rhs.cameraRevision)
     #expect(lhs.cameraDirtyFields == rhs.cameraDirtyFields)
     #expect(lhs.sceneFrameID == rhs.sceneFrameID)
+    #expect(lhs.dependencies == rhs.dependencies)
+}
+
+private func makeDependencies(followedObject: CameraFollowSnapshotDependency? = nil,
+                              navigation: CameraNavigationSnapshotDependency? = nil,
+                              transfer: CameraTransferSnapshotDependency? = nil,
+                              activeCameraMotionRevision: Int = 0,
+                              sceneFrameID: UInt64? = nil,
+                              viewportSize: CGSize = CGSize(width: 200, height: 100),
+                              projection: CameraProjectionParameters) -> CameraSnapshotDependencies {
+    CameraSnapshotDependencies(followedObject: followedObject,
+                               navigation: navigation,
+                               transfer: transfer,
+                               activeCameraMotionRevision: activeCameraMotionRevision,
+                               sceneFrameID: sceneFrameID,
+                               viewportSize: viewportSize,
+                               projection: projection)
 }
 
 private func expectVector(_ lhs: SIMD3<Float>,

--- a/RFC/ADR/0003-camera-state-snapshot-pipeline.md
+++ b/RFC/ADR/0003-camera-state-snapshot-pipeline.md
@@ -1,6 +1,6 @@
 # ADR 0003: Camera State Snapshot Pipeline
 
-Status: Proposed
+Status: Accepted
 Date: 21/05/26
 
 ## Context

--- a/RFC/DOT/30052026-CameraControllers.dot
+++ b/RFC/DOT/30052026-CameraControllers.dot
@@ -3,7 +3,7 @@ digraph CurrentGitChangesDependencies {
         rankdir=LR,
         bgcolor="white",
         fontname="Helvetica",
-        label="Current Git Changes: Route Navigation ADR 0003 Dependency Graph",
+        label="ADR 0003 Accepted: Camera State Snapshot Pipeline Dependency Graph",
         labelloc=t,
         fontsize=20
     ];
@@ -35,6 +35,7 @@ digraph CurrentGitChangesDependencies {
         LegendSnapshot [label="snapshot derivation", fillcolor="#ede9fe"];
         LegendRender [label="render consumption", fillcolor="#ffedd5"];
         LegendMode [label="current camera mode", fillcolor="#dcfce7"];
+        LegendDependency [label="snapshot dependency key", fillcolor="#f3e8ff"];
     }
 
     subgraph cluster_composition {
@@ -93,6 +94,10 @@ digraph CurrentGitChangesDependencies {
             label="CameraProjectionParameters\ngeneric near/far input",
             fillcolor="#ede9fe"
         ];
+        CameraNavigationSnapshotDependency [
+            label="CameraNavigationSnapshotDependency\nroute id/progress/state/transition",
+            fillcolor="#f3e8ff"
+        ];
     }
 
     subgraph cluster_transfer_preview {
@@ -104,6 +109,10 @@ digraph CurrentGitChangesDependencies {
             label="TransferOrbitController\npreview lifecycle owner",
             fillcolor="#ede9fe"
         ];
+        CameraTransferSnapshotDependency [
+            label="CameraTransferSnapshotDependency\ndestination + transition flag",
+            fillcolor="#f3e8ff"
+        ];
     }
 
     subgraph cluster_camera {
@@ -112,7 +121,7 @@ digraph CurrentGitChangesDependencies {
         style="rounded";
 
         CameraCoordinator [
-            label="CameraCoordinator\nroutes camera ownership\ncommits manual transactions",
+            label="CameraCoordinator\nroutes ownership + frame camera tick\nbuilds snapshot dependencies",
             fillcolor="#dcfce7"
         ];
         NavigationCameraCoordinating [
@@ -134,6 +143,10 @@ digraph CurrentGitChangesDependencies {
         FollowCameraOwner [
             label="FollowCameraOwner\nowns current follow lifecycle",
             fillcolor="#dcfce7"
+        ];
+        CameraFollowSnapshotDependency [
+            label="CameraFollowSnapshotDependency\nfollow target position/radius/transition",
+            fillcolor="#f3e8ff"
         ];
         FollowCameraMode [
             label="FollowCameraMode\ncomputes follow transactions",
@@ -164,12 +177,20 @@ digraph CurrentGitChangesDependencies {
             fillcolor="#dcfce7"
         ];
         SnapshotProvider [
-            label="SnapshotProvider\nmode-independent camera snapshot producer",
+            label="SnapshotProvider\nfull dependency-keyed snapshot producer",
             fillcolor="#ede9fe"
         ];
         CameraSnapshot [
-            label="SnapshotProvider.CameraSnapshot\nimmutable render camera",
+            label="SnapshotProvider.CameraSnapshot\nimmutable render camera\nmatrices + origin + camera offset/world position",
             fillcolor="#ede9fe"
+        ];
+        CameraSnapshotDependencies [
+            label="CameraSnapshotDependencies\nfollow + nav + transfer + motion revision\nscene frame + viewport + projection",
+            fillcolor="#f3e8ff"
+        ];
+        CameraFrameModeState [
+            label="CameraFrameModeState\nlightweight per-frame controller state",
+            fillcolor="#f3e8ff"
         ];
         PreparedRenderSnapshotProvider [
             label="PreparedRenderSnapshotProviding\nscene snapshot source",
@@ -183,7 +204,11 @@ digraph CurrentGitChangesDependencies {
         style="rounded";
 
         MetalRenderer [
-            label="MetalRenderer\nticks controllers + composes render state",
+            label="MetalRenderer\nticks route/preview controllers\nrequests camera snapshot + composes render state",
+            fillcolor="#ffedd5"
+        ];
+        MetalRendererCameraFrame [
+            label="MetalRenderer+CameraFrame\nmode state + projection + snapshot assembly",
             fillcolor="#ffedd5"
         ];
         DrawFirstPass [
@@ -280,6 +305,11 @@ digraph CurrentGitChangesDependencies {
         label="exposes routeRenderState",
         color="#ea580c"
     ];
+    NavigationController -> CameraNavigationSnapshotDependency [
+        label="exposes cameraSnapshotDependency",
+        color="#7c3aed",
+        penwidth=2
+    ];
     NavigationControllerRoute -> NavigationRouteCoordinator [
         label="start/pause/resume/cancel/done",
         color="#2563eb"
@@ -322,6 +352,11 @@ digraph CurrentGitChangesDependencies {
         color="#7c3aed",
         penwidth=2
     ];
+    TransferOrbitController -> CameraTransferSnapshotDependency [
+        label="exposes cameraSnapshotDependency",
+        color="#7c3aed",
+        penwidth=2
+    ];
     TransferOrbitController -> TransferPreview [
         label="publishes renderState",
         color="#ea580c",
@@ -344,8 +379,18 @@ digraph CurrentGitChangesDependencies {
         penwidth=2
     ];
     CameraCoordinator -> CameraState [
-        label="commits manual transactions\n+ refreshes derived values",
+        label="commits manual transactions\n+ enforces constraints",
         color="#16a34a",
+        penwidth=2
+    ];
+    CameraCoordinator -> CameraFrameModeState [
+        label="receives updateFrameCamera mode state",
+        color="#7c3aed",
+        penwidth=2
+    ];
+    CameraCoordinator -> CameraSnapshotDependencies [
+        label="makeSnapshotDependencies()",
+        color="#7c3aed",
         penwidth=2
     ];
     CameraCoordinator -> OrbitCameraMode [
@@ -402,6 +447,11 @@ digraph CurrentGitChangesDependencies {
         label="reads latest scene snapshot",
         color="#7c3aed"
     ];
+    FollowCameraOwner -> CameraFollowSnapshotDependency [
+        label="publishes follow dependency signature",
+        color="#7c3aed",
+        penwidth=2
+    ];
     NavigationCameraOwner -> NavigationCameraMode [
         label="owns mode math",
         color="#16a34a",
@@ -445,7 +495,32 @@ digraph CurrentGitChangesDependencies {
         color="#7c3aed"
     ];
     CameraProjectionParameters -> SnapshotProvider [
-        label="explicit mode-agnostic near/far",
+        label="included in dependency key",
+        color="#7c3aed",
+        penwidth=2
+    ];
+    CameraFollowSnapshotDependency -> CameraSnapshotDependencies [
+        label="included",
+        color="#7c3aed"
+    ];
+    CameraNavigationSnapshotDependency -> CameraSnapshotDependencies [
+        label="included",
+        color="#7c3aed"
+    ];
+    CameraTransferSnapshotDependency -> CameraSnapshotDependencies [
+        label="included",
+        color="#7c3aed"
+    ];
+    CameraFrameModeState -> CameraSnapshotDependencies [
+        label="nav/transfer dependencies",
+        color="#7c3aed"
+    ];
+    CameraProjectionParameters -> CameraSnapshotDependencies [
+        label="projection dependency",
+        color="#7c3aed"
+    ];
+    CameraSnapshotDependencies -> SnapshotProvider [
+        label="full cache key with camera revision/dirty fields",
         color="#7c3aed",
         penwidth=2
     ];
@@ -456,24 +531,38 @@ digraph CurrentGitChangesDependencies {
     ];
 
     MetalRenderer -> NavigationController [
-        label="ticks route navigation; reads controlsCamera",
+        label="ticks route navigation",
         color="#ea580c"
     ];
     MetalRenderer -> TransferOrbitController [
-        label="ticks preview; reads render/projection state",
+        label="ticks preview",
         color="#ea580c"
     ];
-    MetalRenderer -> CameraProjectionParameters [
+    MetalRenderer -> MetalRendererCameraFrame [
+        label="delegates camera-frame assembly",
+        color="#ea580c",
+        penwidth=2
+    ];
+    MetalRendererCameraFrame -> CameraFrameModeState [
+        label="builds from controller state",
+        color="#7c3aed",
+        penwidth=2
+    ];
+    MetalRendererCameraFrame -> CameraProjectionParameters [
         label="composes base + follow + preview + navigation projection",
         color="#7c3aed",
         penwidth=2
     ];
     MetalRenderer -> CameraCoordinator [
-        label="ticks follow mode; reads follow projection policy",
+        label="updateFrameCamera()",
         color="#16a34a",
         penwidth=2
     ];
-    MetalRenderer -> SnapshotProvider [
+    MetalRendererCameraFrame -> CameraCoordinator [
+        label="requests dependencies",
+        color="#16a34a"
+    ];
+    MetalRendererCameraFrame -> SnapshotProvider [
         label="requests CameraSnapshot",
         color="#7c3aed",
         penwidth=2


### PR DESCRIPTION
* Added explicit CameraSnapshotDependencies and cache-key coverage for follow, navigation, transfer, scene frame, viewport, projection, and active camera motion.
* Moved render-frame camera ticking behind CameraCoordinator.updateFrameCamera(...).
* Split camera snapshot position semantics into cameraOffset and cameraWorldPosition.
* Updated renderer consumption to use the immutable camera snapshot path.
* Added MetalRenderer+CameraFrame.swift for camera-frame assembly helpers.
* Extended SnapshotProviderTests for the new invalidation cases.
* Marked ADR 0003 as Accepted.
* Fixed the cameraCoordniator typo.
* Updated 30052026-CameraControllers.dot

Resolves #313
Resolves #311 
Resolves #312 
