### PR TITLE
Restore trajectory pan viewport scaling

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraController.swift
@@ -31,7 +31,9 @@ final class CameraController: NSObject, UIGestureRecognizerDelegate {
         beginManualCameraControl()
 
         let translation = gesture.translation(in: gesture.view)
-        cameraCoordinator.makeTranslation(with: translation)
+        let viewportSize = gesture.view?.bounds.size ?? .zero
+        cameraCoordinator.makeTranslation(with: translation,
+                                          viewportSize: viewportSize)
         gesture.setTranslation(.zero, in: gesture.view)
     }
 

--- a/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/CameraCoordinator/CameraCoordinator.swift
@@ -72,12 +72,21 @@ final class CameraCoordinator {
         transferPreviewCameraOwner = .init(cameraState: cameraState)
     }
 
-    func makeTranslation(with value: CGPoint) {
+    func makeTranslation(with value: CGPoint,
+                         viewportSize: CGSize) {
+        guard viewportSize.width.isFinite,
+              viewportSize.height.isFinite,
+              viewportSize.width > 0,
+              viewportSize.height > 0 else {
+            return
+        }
+
         let camera = TrajectoryCameraMode.CameraInput(distance: cameraState.cameraDistance,
                                                       orientation: cameraState.cameraOrientation,
                                                       target: cameraState.cameraTarget)
         commitManualCameraTransaction(
             trajectoryMode.makePanTransaction(translation: value,
+                                              viewportSize: viewportSize,
                                               camera: camera)
         )
     }

--- a/Modules/MetalModule/Sources/MetalModule/Camera/Modes/TrajectoryCameraMode.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/Modes/TrajectoryCameraMode.swift
@@ -6,7 +6,7 @@
 //
 
 import simd
-import CoreFoundation
+import CoreGraphics
 
 /// Transformations for the trajectory camera mode
 final class TrajectoryCameraMode {
@@ -44,10 +44,11 @@ final class TrajectoryCameraMode {
     }
 
     func makePanTransaction(translation: CGPoint,
+                            viewportSize: CGSize,
                             camera: CameraInput) -> CameraState.Transaction {
         makePanTransaction(
-            width: Float(300),
-            height: Float(400),
+            width: Float(viewportSize.width),
+            height: Float(viewportSize.height),
             translation: translation,
             speed: trajectoryPanSpeed,
             camera: camera

--- a/Modules/MetalModule/Tests/MetalModuleTests/ManualCameraModeTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/ManualCameraModeTests.swift
@@ -132,9 +132,41 @@ import Testing
     let fixture = ManualCameraCoordinatorFixture()
     let initialRevision = fixture.cameraState.revision
 
-    fixture.cameraCoordinator.makeTranslation(with: CGPoint(x: 30, y: 40))
+    fixture.cameraCoordinator.makeTranslation(with: CGPoint(x: 30, y: 40),
+                                              viewportSize: CGSize(width: 900, height: 1200))
 
     #expect(fixture.cameraState.revision == initialRevision + 1)
+}
+
+@MainActor
+@Test func cameraCoordinatorTrajectoryPanUsesViewportSize() {
+    let fixture = ManualCameraCoordinatorFixture()
+    let viewportSize = CGSize(width: 900, height: 1200)
+
+    fixture.cameraCoordinator.makeTranslation(with: CGPoint(x: 30, y: 40),
+                                              viewportSize: viewportSize)
+
+    let visibleHeight = 2 * fixture.cameraState.cameraDistance * tan(CameraFit.verticalFieldOfView / 2)
+    let visibleWidth = visibleHeight * Float(viewportSize.width / viewportSize.height)
+    let expectedTarget = SIMD3<Float>(
+        Float(30) / Float(viewportSize.width) * visibleWidth,
+        Float(40) / Float(viewportSize.height) * visibleHeight,
+        0
+    )
+
+    #expect(simd_length(fixture.cameraState.cameraTarget - expectedTarget) < 0.000001)
+}
+
+@MainActor
+@Test func cameraCoordinatorTrajectoryPanSkipsInvalidViewportSize() {
+    let fixture = ManualCameraCoordinatorFixture()
+    let initialRevision = fixture.cameraState.revision
+
+    fixture.cameraCoordinator.makeTranslation(with: CGPoint(x: 30, y: 40),
+                                              viewportSize: .zero)
+
+    #expect(fixture.cameraState.revision == initialRevision)
+    #expect(fixture.cameraState.cameraTarget == .zero)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Pass the live `MTKView` bounds through the trajectory pan gesture path instead of relying on the old `300x400` fallback.
- Keep trajectory pan math unchanged while guarding against invalid viewport sizes at the coordinator boundary.
- Add unit coverage for viewport-aware trajectory pan behavior and invalid-size handling.

Resolves #297 

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`