### PR TITLE
Restore object framing after route cancel

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources+MetalModuleTransferOrbitControlling.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Factory/MetalModuleResources/MetalModuleResources+MetalModuleTransferOrbitControlling.swift
@@ -17,6 +17,6 @@ extension MetalModuleResources: MetalModuleTransferOrbitControlling {
     }
 
     public func clearTransferOrbit() {
-        transferOrbitController.clearTransferOrbit()
+        transferOrbitController.cancelTransferOrbit()
     }
 }

--- a/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Modes/TransferOrbit/TransferOrbitController.swift
@@ -72,6 +72,15 @@ final class TransferOrbitController {
         cameraTransition = nil
     }
 
+    func cancelTransferOrbit() {
+        let destinationName = activeDestinationName ?? pendingDestinationName
+
+        clearTransferOrbit()
+
+        guard let destinationName else { return }
+        followPlanet?(destinationName)
+    }
+
     func beginManualCameraControl() {
         cameraTransition = nil
     }

--- a/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
@@ -40,6 +40,35 @@ import Testing
 }
 
 @MainActor
+@Test func navigationControllerCancelRestoresDestinationFollowCamera() {
+    let fixture = NavigationControllerFixture()
+    fixture.controller.followPlanet = { name in
+        fixture.cameraCoordinator.followNavigationDestination(named: name,
+                                                              viewportSize: fixture.viewportSize)
+    }
+
+    fixture.controller.startNavigation(to: "Mars")
+    fixture.controller.cancelNavigation()
+    #expect(!fixture.cameraCoordinator.isNavigationCameraActive)
+
+    fixture.cameraCoordinator.updateFrameCamera(
+        snapshot: fixture.snapshot,
+        delta: 1.2,
+        viewportSize: fixture.viewportSize,
+        modeState: CameraFrameModeState(navigationControlsCamera: false,
+                                        navigation: nil,
+                                        transferPreviewActive: false,
+                                        transfer: nil)
+    )
+
+    let expectedDistance = CameraFit.distanceToFit(radius: 0.05,
+                                                   currentDistance: fixture.cameraState.cameraDistance,
+                                                   viewportSize: fixture.viewportSize)
+    #expect(fixture.cameraState.cameraTarget == SIMD3<Float>(1.52, 0, 0))
+    #expect(abs(fixture.cameraState.cameraDistance - expectedDistance) < 0.000001)
+}
+
+@MainActor
 @Test func navigationControllerDisablingFollowUsesOverviewCameraTransition() {
     let fixture = NavigationControllerFixture()
 
@@ -124,6 +153,7 @@ import Testing
 
 @MainActor
 private struct NavigationControllerFixture {
+    let viewportSize = CGSize(width: 390, height: 844)
     let snapshot = PreparedRenderSnapshot.navigationControllerTestSnapshot
     let source: FakeNavigationSnapshotSource
     let provider: SnapshotProvider
@@ -132,6 +162,7 @@ private struct NavigationControllerFixture {
     let controller: NavigationController
 
     init(routePlayback: RoutePlayback = RoutePlaybackController()) {
+        let viewportSize = self.viewportSize
         source = FakeNavigationSnapshotSource(latestSnapshot: snapshot)
         cameraState = CameraState()
         provider = SnapshotProvider(cameraState: cameraState,
@@ -141,7 +172,7 @@ private struct NavigationControllerFixture {
         controller = NavigationController(snapshotProvider: provider,
                                           cameraCoordinator: cameraCoordinator,
                                           planets: testPlanets,
-                                          viewportSize: { CGSize(width: 390, height: 844) },
+                                          viewportSize: { viewportSize },
                                           routePlayback: routePlayback)
     }
 }

--- a/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
@@ -67,6 +67,35 @@ import Testing
 }
 
 @MainActor
+@Test func transferOrbitControllerCancelRestoresDestinationFollowCamera() throws {
+    let fixture = TransferOrbitControllerFixture()
+    fixture.controller.followPlanet = { name in
+        fixture.cameraCoordinator.followNavigationDestination(named: name,
+                                                              viewportSize: fixture.viewportSize)
+    }
+
+    fixture.controller.showTransferOrbit(to: "Mars")
+    fixture.controller.update(snapshot: fixture.source.latestSnapshot,
+                              delta: 0.1)
+    #expect(fixture.cameraState.cameraTarget != SIMD3<Float>(1.52, 0, 0))
+
+    fixture.controller.cancelTransferOrbit()
+    fixture.cameraCoordinator.updateFrameCamera(
+        snapshot: fixture.source.latestSnapshot,
+        delta: 1.2,
+        viewportSize: fixture.viewportSize,
+        modeState: CameraFrameModeState(navigationControlsCamera: false,
+                                        navigation: nil,
+                                        transferPreviewActive: false,
+                                        transfer: nil)
+    )
+
+    #expect(!fixture.controller.isTransferPreviewActive)
+    #expect(fixture.controller.renderState == .inactive)
+    #expect(fixture.cameraState.cameraTarget == SIMD3<Float>(1.52, 0, 0))
+}
+
+@MainActor
 @Test func sceneRouteRenderStateUsesTransferPreviewRenderState() throws {
     let fixture = TransferOrbitControllerFixture()
 
@@ -83,6 +112,7 @@ import Testing
 
 @MainActor
 private struct TransferOrbitControllerFixture {
+    let viewportSize = CGSize(width: 390, height: 844)
     let source: FakeTransferSnapshotSource
     let provider: SnapshotProvider
     let cameraState: CameraState
@@ -90,6 +120,7 @@ private struct TransferOrbitControllerFixture {
     let controller: TransferOrbitController
 
     init(latestSnapshot: PreparedRenderSnapshot? = .transferOrbitControllerTestSnapshot) {
+        let viewportSize = self.viewportSize
         source = FakeTransferSnapshotSource(latestSnapshot: latestSnapshot)
         cameraState = CameraState()
         provider = SnapshotProvider(cameraState: cameraState,
@@ -99,7 +130,7 @@ private struct TransferOrbitControllerFixture {
         controller = TransferOrbitController(snapshotProvider: provider,
                                              cameraCoordinator: cameraCoordinator,
                                              planets: testPlanets,
-                                             viewportSize: { CGSize(width: 390, height: 844) })
+                                             viewportSize: { viewportSize })
     }
 }
 


### PR DESCRIPTION
## Summary
- Restore follow/orbit framing when transfer-route preview is cancelled
- Keep transfer-orbit cleanup separate from the user-facing cancel path
- Add camera-level regression coverage for transfer cancel and navigation cancel

## Testing
- `xcodebuild -scheme MetalModule -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO` passed with the new unit tests
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO` passed