### PR TITLE
Add surface coordinate math and debug logging

### DIFF
--- a/Modules/MetalModule/Sources/MetalModule/Camera/SurfaceCoordinateDebugLogger.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SurfaceCoordinateDebugLogger.swift
@@ -1,0 +1,60 @@
+//
+//  SurfaceCoordinateDebugLogger.swift
+//  MetalModule
+//
+//  Created by Codex on 06.06.2026.
+//
+
+import os
+import simd
+
+final class SurfaceCoordinateDebugLogger {
+    private let logger = Logger(subsystem: "OptiUniverse.MetalModule",
+                                category: "SurfaceCoordinates")
+    private let minimumFrameInterval: UInt64
+    private var lastLoggedFrameIDByBody: [String: UInt64] = [:]
+
+    init(minimumFrameInterval: UInt64 = 30) {
+        self.minimumFrameInterval = minimumFrameInterval
+    }
+
+    func logIfNeeded(bodyName: String,
+                     planet: PreparedPlanetRenderPacket,
+                     snapshot: PreparedRenderSnapshot,
+                     cameraSnapshot: SnapshotProvider.CameraSnapshot) {
+        guard shouldLog(bodyName: bodyName,
+                        frameID: snapshot.frameID) else {
+            return
+        }
+
+        guard let hit = SurfaceCoordinateMath.centerRayIntersection(
+            cameraWorldPosition: cameraSnapshot.cameraWorldPosition,
+            cameraTarget: cameraSnapshot.sceneOrigin,
+            planet: planet
+        ), let coordinate = SurfaceCoordinateMath.coordinate(on: planet,
+                                                             forWorldPoint: hit.worldPoint) else {
+            return
+        }
+
+        lastLoggedFrameIDByBody[bodyName] = snapshot.frameID
+        logger.debug(
+            """
+            Surface coordinate body=\(bodyName, privacy: .private) \
+            latitude=\(coordinate.latitudeDegrees, privacy: .private) \
+            longitude=\(coordinate.longitudeDegrees, privacy: .private) \
+            frameID=\(snapshot.frameID, privacy: .public) \
+            simulationTime=\(snapshot.simulationTime, privacy: .public)
+            """
+        )
+    }
+
+    private func shouldLog(bodyName: String,
+                           frameID: UInt64) -> Bool {
+        guard let lastLoggedFrameID = lastLoggedFrameIDByBody[bodyName],
+              frameID >= lastLoggedFrameID else {
+            return true
+        }
+
+        return frameID - lastLoggedFrameID >= minimumFrameInterval
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Camera/SurfaceCoordinateMath.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Camera/SurfaceCoordinateMath.swift
@@ -1,0 +1,124 @@
+//
+//  SurfaceCoordinateMath.swift
+//  MetalModule
+//
+//  Created by Codex on 06.06.2026.
+//
+
+import Foundation
+import simd
+
+struct SurfaceCoordinate: Equatable, Sendable {
+    let latitudeDegrees: Float
+    let longitudeDegrees: Float
+}
+
+struct SurfaceRaySphereHit: Equatable, Sendable {
+    let worldPoint: SIMD3<Float>
+    let distance: Float
+    let isTangent: Bool
+}
+
+enum SurfaceCoordinateMath {
+    private static let epsilon: Float = 0.000001
+
+    static func localUnitVector(for coordinate: SurfaceCoordinate) -> SIMD3<Float> {
+        let latitude = coordinate.latitudeDegrees * .pi / 180
+        let longitude = coordinate.longitudeDegrees * .pi / 180
+        let equatorRadius = cos(latitude)
+        let vector = SIMD3<Float>(
+            equatorRadius * cos(longitude),
+            equatorRadius * sin(longitude),
+            sin(latitude)
+        )
+
+        guard simd_length_squared(vector) > epsilon * epsilon else {
+            return SIMD3<Float>(1, 0, 0)
+        }
+        return simd_normalize(vector)
+    }
+
+    static func coordinate(fromLocalUnitVector vector: SIMD3<Float>) -> SurfaceCoordinate? {
+        guard simd_length_squared(vector) > epsilon * epsilon else {
+            return nil
+        }
+
+        let unitVector = simd_normalize(vector)
+        let clampedZ = min(max(unitVector.z, -1), 1)
+        let latitude = asin(clampedZ) * 180 / .pi
+        let longitude = atan2(unitVector.y, unitVector.x) * 180 / .pi
+        return SurfaceCoordinate(latitudeDegrees: latitude,
+                                 longitudeDegrees: normalizedLongitude(longitude))
+    }
+
+    static func worldSurfacePoint(on planet: PreparedPlanetRenderPacket,
+                                  at coordinate: SurfaceCoordinate) -> SIMD3<Float> {
+        let localPoint = localUnitVector(for: coordinate) * planet.surfaceRadius
+        let worldPoint = planet.baseModelMatrix * SIMD4<Float>(localPoint, 1)
+        return SIMD3<Float>(worldPoint.x, worldPoint.y, worldPoint.z)
+    }
+
+    static func coordinate(on planet: PreparedPlanetRenderPacket,
+                           forWorldPoint worldPoint: SIMD3<Float>) -> SurfaceCoordinate? {
+        let localPoint = simd_inverse(planet.baseModelMatrix) * SIMD4<Float>(worldPoint, 1)
+        return coordinate(fromLocalUnitVector: SIMD3<Float>(localPoint.x,
+                                                            localPoint.y,
+                                                            localPoint.z))
+    }
+
+    static func referenceSphereIntersection(rayOrigin: SIMD3<Float>,
+                                            rayDirection: SIMD3<Float>,
+                                            planet: PreparedPlanetRenderPacket)
+    -> SurfaceRaySphereHit? {
+        guard planet.surfaceRadius > epsilon else { return nil }
+        guard simd_length_squared(rayDirection) > epsilon * epsilon else { return nil }
+
+        let direction = simd_normalize(rayDirection)
+        let offset = rayOrigin - planet.worldPosition
+        let linearTerm = 2 * simd_dot(offset, direction)
+        let constantTerm = simd_dot(offset, offset) - planet.surfaceRadius * planet.surfaceRadius
+        let discriminant = linearTerm * linearTerm - 4 * constantTerm
+
+        guard discriminant >= -epsilon else {
+            return nil
+        }
+
+        let isTangent = abs(discriminant) <= epsilon
+        let squareRoot = sqrt(max(discriminant, 0))
+        let nearDistance = (-linearTerm - squareRoot) * 0.5
+        let farDistance = (-linearTerm + squareRoot) * 0.5
+        let distance: Float
+        if nearDistance >= 0 {
+            distance = nearDistance
+        } else if farDistance >= 0 {
+            distance = farDistance
+        } else {
+            return nil
+        }
+
+        return SurfaceRaySphereHit(worldPoint: rayOrigin + direction * distance,
+                                   distance: distance,
+                                   isTangent: isTangent)
+    }
+
+    static func centerRayIntersection(cameraWorldPosition: SIMD3<Float>,
+                                      cameraTarget: SIMD3<Float>,
+                                      planet: PreparedPlanetRenderPacket)
+    -> SurfaceRaySphereHit? {
+        referenceSphereIntersection(
+            rayOrigin: cameraWorldPosition,
+            rayDirection: cameraTarget - cameraWorldPosition,
+            planet: planet
+        )
+    }
+
+    private static func normalizedLongitude(_ longitude: Float) -> Float {
+        var normalized = longitude.truncatingRemainder(dividingBy: 360)
+        if normalized >= 180 {
+            normalized -= 360
+        } else if normalized < -180 {
+            normalized += 360
+        }
+        return normalized
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+SurfaceCoordinates.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+SurfaceCoordinates.swift
@@ -1,0 +1,34 @@
+//
+//  MetalRenderer+SurfaceCoordinates.swift
+//  MetalModule
+//
+//  Created by Codex on 06.06.2026.
+//
+
+extension MetalRenderer {
+    func logSurfaceCoordinateDebug(snapshot: PreparedRenderSnapshot?,
+                                   cameraSnapshot: SnapshotProvider.CameraSnapshot,
+                                   modeState: CameraFrameModeState) {
+        guard let snapshot,
+              let bodyName = surfaceCoordinateDebugTargetName(cameraSnapshot: cameraSnapshot,
+                                                              modeState: modeState),
+              let planet = snapshot.planet(named: bodyName) else {
+            return
+        }
+
+        surfaceCoordinateDebugLogger.logIfNeeded(bodyName: bodyName,
+                                                 planet: planet,
+                                                 snapshot: snapshot,
+                                                 cameraSnapshot: cameraSnapshot)
+    }
+
+    private func surfaceCoordinateDebugTargetName(cameraSnapshot: SnapshotProvider.CameraSnapshot,
+                                                  modeState: CameraFrameModeState) -> String? {
+        if modeState.navigationControlsCamera,
+           let destinationName = modeState.navigation?.destinationName {
+            return destinationName
+        }
+
+        return cameraSnapshot.dependencies.followedObject?.planetName
+    }
+}

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -27,6 +27,7 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     let objectInfoOverlayFramingState: ObjectInfoOverlayFramingState
     let navigationController: NavigationController
     let transferOrbitController: TransferOrbitController
+    let surfaceCoordinateDebugLogger = SurfaceCoordinateDebugLogger()
     let metalView: MTKView
     let depthStencilState: MTLDepthStencilState
 
@@ -173,6 +174,9 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
         let cameraSnapshot = makeCameraSnapshot(snapshot: snapshot,
                                                 projection: projection,
                                                 modeState: modeState)
+        logSurfaceCoordinateDebug(snapshot: snapshot,
+                                  cameraSnapshot: cameraSnapshot,
+                                  modeState: modeState)
 
         do {
             try drawFirstPass(msaaColorTexture: msaaColorTexture,

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/RenderPreparationPipeline/PreparedPlanetRenderPacket.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/RenderPreparationPipeline/PreparedPlanetRenderPacket.swift
@@ -15,5 +15,6 @@ struct PreparedPlanetRenderPacket: Sendable {
     let normalizedScale: Float
     let primaryMeshRadius: Float
     let framingRadius: Float
+    let surfaceRadius: Float
     let worldPosition: SIMD3<Float>
 }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/RenderPreparationPipeline/RenderPreparationPipeline.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/RenderPreparationPipeline/RenderPreparationPipeline.swift
@@ -91,6 +91,7 @@ final class RenderPreparationPipeline: PreparedRenderSnapshotProviding {
                     normalizedScale: normalizedScale,
                     primaryMeshRadius: primaryMeshRadius,
                     framingRadius: framingRadius,
+                    surfaceRadius: framingRadius,
                     worldPosition: worldPosition
                 )
             )

--- a/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraModeTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/FollowCameraModeTests.swift
@@ -86,6 +86,7 @@ extension PreparedRenderSnapshot {
                                    normalizedScale: 1,
                                    primaryMeshRadius: framingRadius,
                                    framingRadius: framingRadius,
+                                   surfaceRadius: framingRadius,
                                    worldPosition: worldPosition)
     }
 }

--- a/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/NavigationControllerTests.swift
@@ -245,6 +245,7 @@ private extension PreparedRenderSnapshot {
                                    normalizedScale: 1,
                                    primaryMeshRadius: framingRadius,
                                    framingRadius: framingRadius,
+                                   surfaceRadius: framingRadius,
                                    worldPosition: worldPosition)
     }
 }

--- a/Modules/MetalModule/Tests/MetalModuleTests/SurfaceCoordinateMathTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/SurfaceCoordinateMathTests.swift
@@ -1,0 +1,166 @@
+import simd
+import Testing
+@testable import MetalModule
+
+@Test func surfaceCoordinateAxisConventions() {
+    expectVector(SurfaceCoordinateMath.localUnitVector(
+        for: SurfaceCoordinate(latitudeDegrees: 0,
+                               longitudeDegrees: 0)
+    ), equals: SIMD3<Float>(1, 0, 0))
+    expectVector(SurfaceCoordinateMath.localUnitVector(
+        for: SurfaceCoordinate(latitudeDegrees: 0,
+                               longitudeDegrees: 90)
+    ), equals: SIMD3<Float>(0, 1, 0))
+    expectVector(SurfaceCoordinateMath.localUnitVector(
+        for: SurfaceCoordinate(latitudeDegrees: 90,
+                               longitudeDegrees: 42)
+    ), equals: SIMD3<Float>(0, 0, 1))
+    expectVector(SurfaceCoordinateMath.localUnitVector(
+        for: SurfaceCoordinate(latitudeDegrees: -90,
+                               longitudeDegrees: 42)
+    ), equals: SIMD3<Float>(0, 0, -1))
+}
+
+@Test func surfaceCoordinateRoundTripsAwayFromPoles() throws {
+    let coordinates = [
+        SurfaceCoordinate(latitudeDegrees: 30,
+                          longitudeDegrees: 45),
+        SurfaceCoordinate(latitudeDegrees: -45,
+                          longitudeDegrees: -135),
+        SurfaceCoordinate(latitudeDegrees: 12.5,
+                          longitudeDegrees: -47.25)
+    ]
+
+    for coordinate in coordinates {
+        let vector = SurfaceCoordinateMath.localUnitVector(for: coordinate)
+        let roundTrip = try #require(
+            SurfaceCoordinateMath.coordinate(fromLocalUnitVector: vector)
+        )
+
+        expectEqual(roundTrip.latitudeDegrees,
+                    coordinate.latitudeDegrees,
+                    tolerance: 0.0001)
+        expectEqual(roundTrip.longitudeDegrees,
+                    coordinate.longitudeDegrees,
+                    tolerance: 0.0001)
+    }
+}
+
+@Test func surfaceRayIntersectsReferenceSphereFromOutside() throws {
+    let planet = testSurfacePlanet()
+
+    let hit = try #require(SurfaceCoordinateMath.referenceSphereIntersection(
+        rayOrigin: SIMD3<Float>(0, 0, 3),
+        rayDirection: SIMD3<Float>(0, 0, -1),
+        planet: planet
+    ))
+
+    expectVector(hit.worldPoint,
+                 equals: SIMD3<Float>(0, 0, 1))
+    expectEqual(hit.distance,
+                2)
+    #expect(hit.isTangent == false)
+}
+
+@Test func surfaceRayMissesReferenceSphere() {
+    let planet = testSurfacePlanet()
+
+    let hit = SurfaceCoordinateMath.referenceSphereIntersection(
+        rayOrigin: SIMD3<Float>(0, 0, 3),
+        rayDirection: SIMD3<Float>(0, 1, 0),
+        planet: planet
+    )
+
+    #expect(hit == nil)
+}
+
+@Test func surfaceRayReportsTangentReferenceSphereHit() throws {
+    let planet = testSurfacePlanet()
+
+    let hit = try #require(SurfaceCoordinateMath.referenceSphereIntersection(
+        rayOrigin: SIMD3<Float>(1, 0, 3),
+        rayDirection: SIMD3<Float>(0, 0, -1),
+        planet: planet
+    ))
+
+    expectVector(hit.worldPoint,
+                 equals: SIMD3<Float>(1, 0, 0))
+    expectEqual(hit.distance,
+                3)
+    #expect(hit.isTangent)
+}
+
+@Test func surfaceRayIntersectsReferenceSphereFromInside() throws {
+    let planet = testSurfacePlanet()
+
+    let hit = try #require(SurfaceCoordinateMath.referenceSphereIntersection(
+        rayOrigin: SIMD3<Float>(0, 0, 0),
+        rayDirection: SIMD3<Float>(1, 0, 0),
+        planet: planet
+    ))
+
+    expectVector(hit.worldPoint,
+                 equals: SIMD3<Float>(1, 0, 0))
+    expectEqual(hit.distance,
+                1)
+}
+
+@Test func worldSurfacePointUsesBaseModelMatrixAndSurfaceRadius() throws {
+    let baseModelMatrix = float4x4.makeTranslation(SIMD3<Float>(10, 20, 30))
+    * float4x4.makeRotationZ(.pi / 2)
+    let planet = testSurfacePlanet(baseModelMatrix: baseModelMatrix,
+                                   surfaceRadius: 2)
+
+    let worldPoint = SurfaceCoordinateMath.worldSurfacePoint(
+        on: planet,
+        at: SurfaceCoordinate(latitudeDegrees: 0,
+                              longitudeDegrees: 0)
+    )
+    let coordinate = try #require(SurfaceCoordinateMath.coordinate(on: planet,
+                                                                   forWorldPoint: worldPoint))
+
+    expectVector(worldPoint,
+                 equals: SIMD3<Float>(10, 22, 30))
+    expectEqual(coordinate.latitudeDegrees,
+                0)
+    expectEqual(coordinate.longitudeDegrees,
+                0)
+}
+
+private func testSurfacePlanet(baseModelMatrix: float4x4 = matrix_identity_float4x4,
+                               surfaceRadius: Float = 1) -> PreparedPlanetRenderPacket {
+    let worldPosition4 = baseModelMatrix * SIMD4<Float>(0, 0, 0, 1)
+    return PreparedPlanetRenderPacket(
+        planetName: "Test",
+        meshes: [],
+        baseModelMatrix: baseModelMatrix,
+        worldModelMatrix: matrix_identity_float4x4,
+        normalizedScale: 1,
+        primaryMeshRadius: surfaceRadius,
+        framingRadius: surfaceRadius,
+        surfaceRadius: surfaceRadius,
+        worldPosition: SIMD3<Float>(worldPosition4.x,
+                                    worldPosition4.y,
+                                    worldPosition4.z)
+    )
+}
+
+private func expectVector(_ lhs: SIMD3<Float>,
+                          equals rhs: SIMD3<Float>,
+                          tolerance: Float = 0.00001) {
+    expectEqual(lhs.x,
+                rhs.x,
+                tolerance: tolerance)
+    expectEqual(lhs.y,
+                rhs.y,
+                tolerance: tolerance)
+    expectEqual(lhs.z,
+                rhs.z,
+                tolerance: tolerance)
+}
+
+private func expectEqual(_ lhs: Float,
+                         _ rhs: Float,
+                         tolerance: Float = 0.000001) {
+    #expect(abs(lhs - rhs) <= tolerance)
+}

--- a/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
+++ b/Modules/MetalModule/Tests/MetalModuleTests/TransferOrbitControllerTests.swift
@@ -172,6 +172,7 @@ private extension PreparedRenderSnapshot {
                                    normalizedScale: 1,
                                    primaryMeshRadius: framingRadius,
                                    framingRadius: framingRadius,
+                                   surfaceRadius: framingRadius,
                                    worldPosition: worldPosition)
     }
 }


### PR DESCRIPTION
## Summary
- Add internal surface-coordinate math helpers and reference-sphere ray intersection logic in `MetalModule`.
- Thread `surfaceRadius` through prepared planet packets and use it for surface point calculations.
- Add throttled private debug logging in `MetalRenderer` for the current follow or navigation target.
- Cover axis conventions, round trips, ray-sphere cases, and transform-aware world-point mapping with unit tests.

Resolves #347 

## Testing
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project OptiUniverse.xcodeproj -scheme OptiUniverse -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test CODE_SIGNING_ALLOWED=NO`
- `swiftlint` passed on the new source and test files