### PR TITLE
Reset orbit and navigation state when returning Home

### DIFF
--- a/OptiUniverse/Features/RootContainer/RootContainerView.swift
+++ b/OptiUniverse/Features/RootContainer/RootContainerView.swift
@@ -70,6 +70,14 @@ struct RootContainerView: View {
         .animation(.default, value: isDataLoaded)
         .animation(.default, value: appEnvironment.currentScreen)
         .animation(.default, value: metalResources.navigation.navigationSnapshot)
+        .onChange(of: appEnvironment.currentScreen) { _, newScreen in
+            guard newScreen == .home else { return }
+
+            cancelObjectPresentationModes()
+        }
+        .onChange(of: appEnvironment.selectedFollowTarget) { _, _ in
+            objectsViewState = .raw
+        }
         .onChange(of: metalResources.navigation.navigationSnapshot.state) { _, newState in
             guard objectsViewState == .navigation,
                   newState == .cancelled else {
@@ -92,6 +100,15 @@ struct RootContainerView: View {
         }
         .animation(.default, value: objectsViewState)
         .animation(.default, value: objectInfoOverlayPresentationID)
+    }
+
+    private func cancelObjectPresentationModes() {
+        metalResources.setObjectInfoOverlayFraming(isPresented: false,
+                                                   bottomInset: 0,
+                                                   viewportHeight: 0)
+        metalResources.transferOrbit.clearTransferOrbit()
+        metalResources.navigation.cancelNavigation()
+        objectsViewState = .raw
     }
 }
 


### PR DESCRIPTION
## Summary
- Cancel object overlay framing, transfer orbit preview, and navigation when the user returns to Home
- Reset the objects screen state back to `raw` when a new follow target is selected so stale orbit UI does not carry over to the next object

Resolves #351 

## Testing
- Built the iOS app successfully with `xcodebuild`
- Ran the app test suite successfully with `xcodebuild test`