### PR TITLE
Remove cartoon shader path from planet rendering

### DIFF
--- a/DebugPanelParameters.md
+++ b/DebugPanelParameters.md
@@ -7,4 +7,3 @@
 | Corona Mode | off, simple, detailed | Rendering technique for corona. |
 | Particle Count | 0–5000 | Number of emitted particles. |
 | Exposure | 0.1–5.0 | Multiplier applied to final color. |
-| Cartoon Shader Intensity | 0.0–1.0 | Blends from current lighting to cel-shaded cartoon rendering. |

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer+DrawFirstPass.swift
@@ -58,8 +58,7 @@ extension MetalRenderer {
                                                       projectionMatrix: state.cameraSnapshot.projectionMatrix,
                                                       cameraOffset: state.cameraSnapshot.cameraOffset,
                                                       sceneOrigin: renderOrigin,
-                                                      viewportSize: state.cameraSnapshot.viewportSize,
-                                                      cartoonShaderIntensity: min(max(cartoonShaderIntensity, 0), 1))
+                                                      viewportSize: state.cameraSnapshot.viewportSize)
         starsRenderer.render(renderEncoder: renderEncoder,
                              viewMatrix: renderViewMatrix,
                              projectionMatrix: state.cameraSnapshot.projectionMatrix,

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/MetalRender/MetalRenderer.swift
@@ -39,7 +39,6 @@ final class MetalRenderer: NSObject, MTKViewDelegate {
     private var postfxMsaaTexture: MTLTexture?
     private(set) var postfxPipelineState: MTLRenderPipelineState!
     var postFXParams = PostFXParams.filmic
-    var cartoonShaderIntensity: Float = 0
 
     let cameraCoordinator: CameraCoordinator
 

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetRenderConfiguration.swift
@@ -16,5 +16,4 @@ struct PlanetRenderConfiguration {
     let cameraOffset: SIMD3<Float>
     let sceneOrigin: SIMD3<Float>
     let viewportSize: CGSize
-    let cartoonShaderIntensity: Float
 }

--- a/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+Render.swift
+++ b/Modules/MetalModule/Sources/MetalModule/Renderers/PlanetsRenderer/PlanetsRenderer+Render.swift
@@ -18,7 +18,6 @@ extension PlanetsRenderer {
         var cameraPosition: SIMD3<Float>
         var exposureScale: Float
         var lightPosition: SIMD3<Float>
-        var cartoonShaderIntensity: Float
         var keyLightColor: SIMD3<Float>
         var terminatorSoftness: Float
         var fillLightColor: SIMD3<Float>
@@ -59,7 +58,6 @@ extension PlanetsRenderer {
             cameraPosition: configuration.cameraOffset,
             exposureScale: 1.08,
             lightPosition: -configuration.sceneOrigin,
-            cartoonShaderIntensity: min(max(configuration.cartoonShaderIntensity, 0), 1),
             keyLightColor: SIMD3<Float>(1.0, 0.86, 0.66),
             terminatorSoftness: 0.24,
             fillLightColor: SIMD3<Float>(0.38, 0.48, 0.72),

--- a/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
+++ b/Modules/MetalModule/Sources/MetalModule/Shaders/Shaders.metal
@@ -80,7 +80,6 @@ struct FragmentUniforms {
     float3 cameraPosition;
     float exposureScale;
     float3 lightPosition;
-    float cartoonShaderIntensity;
     float3 keyLightColor;
     float terminatorSoftness;
     float3 fillLightColor;
@@ -115,81 +114,6 @@ float geometrySmith(float3 normal, float3 viewDir, float3 lightDir, float roughn
 
 float3 fresnelSchlick(float cosTheta, float3 f0) {
     return f0 + (1.0 - f0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
-}
-
-float toonLightBand(float lightAmount) {
-    float light = saturate(lightAmount);
-    if (light < 0.18) {
-        return 0.18;
-    }
-    if (light < 0.45) {
-        return 0.42;
-    }
-    if (light < 0.74) {
-        return 0.72;
-    }
-    return 1.0;
-}
-
-float3 adjustSaturation(float3 color, float saturation) {
-    float luminance = dot(color, float3(0.299, 0.587, 0.114));
-    return mix(float3(luminance), color, saturation);
-}
-
-float luminance(float3 color) {
-    return dot(color, float3(0.299, 0.587, 0.114));
-}
-
-float3 posterizeColor(float3 color, float levels) {
-    return floor(color * levels + 0.5) / levels;
-}
-
-float textureInkLine(texture2d<float> baseTexture,
-                     sampler textureSampler,
-                     float2 uv) {
-    float2 texelSize = 1.0 / float2(max(float(baseTexture.get_width()), 1.0),
-                                    max(float(baseTexture.get_height()), 1.0));
-    texelSize *= 1.35;
-
-    float left = luminance(baseTexture.sample(textureSampler, uv - float2(texelSize.x, 0.0)).rgb);
-    float right = luminance(baseTexture.sample(textureSampler, uv + float2(texelSize.x, 0.0)).rgb);
-    float up = luminance(baseTexture.sample(textureSampler, uv + float2(0.0, texelSize.y)).rgb);
-    float down = luminance(baseTexture.sample(textureSampler, uv - float2(0.0, texelSize.y)).rgb);
-    float diagA = luminance(baseTexture.sample(textureSampler, uv + texelSize).rgb);
-    float diagB = luminance(baseTexture.sample(textureSampler, uv - texelSize).rgb);
-    float diagC = luminance(baseTexture.sample(textureSampler, uv + float2(texelSize.x, -texelSize.y)).rgb);
-    float diagD = luminance(baseTexture.sample(textureSampler, uv + float2(-texelSize.x, texelSize.y)).rgb);
-
-    float edge = max(max(abs(left - right), abs(up - down)),
-                     max(abs(diagA - diagB), abs(diagC - diagD)));
-    return smoothstep(0.025, 0.115, edge);
-}
-
-float3 cartoonShade(float3 litColor,
-                    float3 albedo,
-                    float3 emissive,
-                    float3 normal,
-                    float3 viewDir,
-                    float nDotL,
-                    float ambientOcclusion,
-                    float textureLine,
-                    float intensity) {
-    float bandedLight = toonLightBand(nDotL);
-    float3 saturatedAlbedo = adjustSaturation(albedo, mix(1.0, 1.18, intensity));
-    float3 drawnAlbedo = posterizeColor(saturatedAlbedo, mix(8.0, 5.0, intensity));
-    float lightingRamp = mix(0.78, 1.08, bandedLight);
-    float3 toonColor = drawnAlbedo * lightingRamp * max(ambientOcclusion, 0.58);
-    toonColor += emissive;
-
-    float textureInk = textureLine * mix(0.0, 0.48, intensity);
-    toonColor = mix(toonColor, toonColor * 0.42, textureInk);
-
-    float silhouette = smoothstep(0.34, 0.64, 1.0 - saturate(abs(dot(normal, viewDir))));
-    float3 inkColor = float3(0.0);
-    toonColor = mix(toonColor, inkColor, silhouette * mix(0.0, 0.92, intensity));
-    toonColor = max((toonColor - 0.03) * mix(1.0, 1.18, intensity) + 0.03, 0.0);
-
-    return mix(litColor, toonColor, intensity);
 }
 
 vertex VertexOut vertex_main(
@@ -375,10 +299,6 @@ fragment float4 fragment_main(VertexOut in [[stage_in]],
         alpha *= smoothstep(0.08, 0.72, cloudCoverage);
         albedo = float3(1.0);
     }
-    float textureLine = 0.0;
-    if (planetTexture.get_width() > 2 && planetTexture.get_height() > 2) {
-        textureLine = textureInkLine(planetTexture, textureSampler, uv);
-    }
 
     float3 normal = normalize(in.normal);
     if (normalTexture.get_width() > 0) {
@@ -457,18 +377,6 @@ fragment float4 fragment_main(VertexOut in [[stage_in]],
     }
     if (materialUniforms.whiteAlbedo > 0.5) {
         litColor = albedo * (0.05 + cloudLight * 1.35);
-    }
-    float cartoonIntensity = saturate(fragmentUniforms.cartoonShaderIntensity);
-    if (cartoonIntensity > 0.0) {
-        litColor = cartoonShade(litColor,
-                                albedo,
-                                emissive,
-                                lightingNormal,
-                                viewDir,
-                                nDotL,
-                                ambientOcclusion,
-                                textureLine,
-                                cartoonIntensity);
     }
     if (materialUniforms.unlit <= 0.5) {
         float limb = pow(1.0 - nDotV, 2.0);


### PR DESCRIPTION
## Summary
- Remove the cartoon/cel-shading parameter from the Metal rendering pipeline.
- Delete the cartoon-specific Metal helpers and fragment branch, leaving the standard planet lighting path intact.
- Drop the debug-panel documentation entry for the removed parameter.

Resolves #211 

## Testing
- Build succeeded with `xcodebuild` for the OptiUniverse scheme.
- Unit tests succeeded with the OptiUniverse test run on the iPhone 17 Pro simulator.