### PR TITLE
Separate orbit and self-rotation transforms in RealityKit scene snapshots

### DIFF
--- a/Modules/UniverseModule/Sources/UniverseModule/Camera/SurfaceCoordinateMath.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/Camera/SurfaceCoordinateMath.swift
@@ -28,8 +28,8 @@ enum SurfaceCoordinateMath {
         let equatorRadius = cos(latitude)
         let vector = SIMD3<Float>(
             equatorRadius * cos(longitude),
-            equatorRadius * sin(longitude),
-            sin(latitude)
+            sin(latitude),
+            equatorRadius * sin(longitude)
         )
 
         guard simd_length_squared(vector) > epsilon * epsilon else {
@@ -44,9 +44,9 @@ enum SurfaceCoordinateMath {
         }
 
         let unitVector = simd_normalize(vector)
-        let clampedZ = min(max(unitVector.z, -1), 1)
-        let latitude = asin(clampedZ) * 180 / .pi
-        let longitude = atan2(unitVector.y, unitVector.x) * 180 / .pi
+        let clampedY = min(max(unitVector.y, -1), 1)
+        let latitude = asin(clampedY) * 180 / .pi
+        let longitude = atan2(unitVector.z, unitVector.x) * 180 / .pi
         return SurfaceCoordinate(latitudeDegrees: latitude,
                                  longitudeDegrees: normalizedLongitude(longitude))
     }

--- a/Modules/UniverseModule/Sources/UniverseModule/Models/HohmannTransferOrbit.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/Models/HohmannTransferOrbit.swift
@@ -26,7 +26,7 @@ struct HohmannTransferOrbit: Equatable, Sendable {
               isSupportedDestination(destination),
               earth.distance > 0,
               destination.distance > 0,
-              simd_length_squared(earthSunDirection) > 0.000001 else {
+              horizontalLengthSquared(earthSunDirection) > 0.000001 else {
             return nil
         }
 
@@ -75,7 +75,7 @@ struct HohmannTransferOrbit: Equatable, Sendable {
             let progress = Float(index) / Float(sampleCount - 1)
             let trueAnomaly = departureTrueAnomaly +
             (destinationTrueAnomaly - departureTrueAnomaly) * progress
-            return rotateZ(point(trueAnomaly: trueAnomaly,
+            return rotateY(point(trueAnomaly: trueAnomaly,
                                  eccentricity: eccentricity,
                                  semiLatusRectum: semiLatusRectum),
                            angle: rotationAngle)
@@ -87,26 +87,30 @@ struct HohmannTransferOrbit: Equatable, Sendable {
                               semiLatusRectum: Float) -> SIMD3<Float> {
         let radius = semiLatusRectum / (1 + eccentricity * cos(trueAnomaly))
         return SIMD3<Float>(radius * cos(trueAnomaly),
-                            radius * sin(trueAnomaly),
-                            0)
+                            0,
+                            -radius * sin(trueAnomaly))
     }
 
     private static func signedAngle(from source: SIMD3<Float>,
                                     to destination: SIMD3<Float>) -> Float {
-        let sourceXY = normalize(SIMD2<Float>(source.x, source.y))
-        let destinationXY = normalize(SIMD2<Float>(destination.x, destination.y))
-        let crossValue = sourceXY.x * destinationXY.y - sourceXY.y * destinationXY.x
-        let dotValue = simd_clamp(simd_dot(sourceXY, destinationXY), -1, 1)
+        let sourceXZ = normalize(SIMD2<Float>(source.x, source.z))
+        let destinationXZ = normalize(SIMD2<Float>(destination.x, destination.z))
+        let crossValue = sourceXZ.y * destinationXZ.x - sourceXZ.x * destinationXZ.y
+        let dotValue = simd_clamp(simd_dot(sourceXZ, destinationXZ), -1, 1)
         return atan2(crossValue, dotValue)
     }
 
-    private static func rotateZ(_ point: SIMD3<Float>, angle: Float) -> SIMD3<Float> {
+    private static func rotateY(_ point: SIMD3<Float>, angle: Float) -> SIMD3<Float> {
         let cosine = cos(angle)
         let sine = sin(angle)
         return SIMD3<Float>(
-            point.x * cosine - point.y * sine,
-            point.x * sine + point.y * cosine,
-            point.z
+            point.x * cosine + point.z * sine,
+            point.y,
+            -point.x * sine + point.z * cosine
         )
+    }
+
+    private static func horizontalLengthSquared(_ vector: SIMD3<Float>) -> Float {
+        vector.x * vector.x + vector.z * vector.z
     }
 }

--- a/Modules/UniverseModule/Sources/UniverseModule/Modes/Navigation/Route/RoutePathBuilder.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/Modes/Navigation/Route/RoutePathBuilder.swift
@@ -87,8 +87,8 @@ struct RoutePathBuilder: RouteBuilding {
         let destinationVector = destinationPosition - sunPosition
         let epsilon: Float = 0.000001
 
-        guard simd_length_squared(endpointVector) > epsilon,
-              simd_length_squared(destinationVector) > epsilon else {
+        guard horizontalLengthSquared(endpointVector) > epsilon,
+              horizontalLengthSquared(destinationVector) > epsilon else {
             return transferOrbit.points
         }
 
@@ -102,7 +102,7 @@ struct RoutePathBuilder: RouteBuilding {
         let orbitPoints = (1...arcSampleCount).map { index in
             let progress = Float(index) / Float(arcSampleCount)
             let angle = orbitAngle * progress
-            return sunPosition + rotateZ(startDirection * radius, angle: angle)
+            return sunPosition + rotateY(startDirection * radius, angle: angle)
         }
 
         return transferOrbit.points + orbitPoints
@@ -127,21 +127,25 @@ struct RoutePathBuilder: RouteBuilding {
 
     private static func positiveAngle(from source: SIMD3<Float>,
                                       to destination: SIMD3<Float>) -> Float {
-        let sourceXY = normalize(SIMD2<Float>(source.x, source.y))
-        let destinationXY = normalize(SIMD2<Float>(destination.x, destination.y))
-        let crossValue = sourceXY.x * destinationXY.y - sourceXY.y * destinationXY.x
-        let dotValue = simd_clamp(simd_dot(sourceXY, destinationXY), -1, 1)
+        let sourceXZ = normalize(SIMD2<Float>(source.x, source.z))
+        let destinationXZ = normalize(SIMD2<Float>(destination.x, destination.z))
+        let crossValue = sourceXZ.y * destinationXZ.x - sourceXZ.x * destinationXZ.y
+        let dotValue = simd_clamp(simd_dot(sourceXZ, destinationXZ), -1, 1)
         let signedAngle = atan2(crossValue, dotValue)
         return signedAngle >= 0 ? signedAngle : signedAngle + 2 * .pi
     }
 
-    private static func rotateZ(_ point: SIMD3<Float>, angle: Float) -> SIMD3<Float> {
+    private static func rotateY(_ point: SIMD3<Float>, angle: Float) -> SIMD3<Float> {
         let cosine = cos(angle)
         let sine = sin(angle)
         return SIMD3<Float>(
-            point.x * cosine - point.y * sine,
-            point.x * sine + point.y * cosine,
-            point.z
+            point.x * cosine + point.z * sine,
+            point.y,
+            -point.x * sine + point.z * cosine
         )
+    }
+
+    private static func horizontalLengthSquared(_ vector: SIMD3<Float>) -> Float {
+        vector.x * vector.x + vector.z * vector.z
     }
 }

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/ProceduralScene/RealityProceduralSceneContent.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/ProceduralScene/RealityProceduralSceneContent.swift
@@ -130,11 +130,11 @@ final class RealityProceduralSceneContent {
         navigationMarker.scale = SIMD3<Float>(repeating: cameraDistance * 0.008 * pulse)
     }
 
-    private static func circlePoints(center: SIMD3<Float>, radius: Float) -> [SIMD3<Float>] {
+    static func circlePoints(center: SIMD3<Float>, radius: Float) -> [SIMD3<Float>] {
         guard radius.isFinite, radius > 0 else { return [] }
         return (0...transferSampleCount).map { index in
             let angle = Float(index) / Float(transferSampleCount) * 2 * .pi
-            return center + SIMD3<Float>(radius * cos(angle), radius * sin(angle), 0)
+            return center + SIMD3<Float>(radius * cos(angle), 0, -radius * sin(angle))
         }
     }
 

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/SceneSnapshot/CelestialBodySnapshot.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/SceneSnapshot/CelestialBodySnapshot.swift
@@ -10,8 +10,28 @@ import simd
 struct CelestialBodySnapshot: Sendable {
     let planetName: String
     let baseModelMatrix: float4x4
+    let orbitTransformMatrix: float4x4
+    let visualRotationMatrix: float4x4
     let normalizedScale: Float
     let framingRadius: Float
     let surfaceRadius: Float
     let worldPosition: SIMD3<Float>
+
+    init(planetName: String,
+         baseModelMatrix: float4x4,
+         orbitTransformMatrix: float4x4 = matrix_identity_float4x4,
+         visualRotationMatrix: float4x4 = matrix_identity_float4x4,
+         normalizedScale: Float,
+         framingRadius: Float,
+         surfaceRadius: Float,
+         worldPosition: SIMD3<Float>) {
+        self.planetName = planetName
+        self.baseModelMatrix = baseModelMatrix
+        self.orbitTransformMatrix = orbitTransformMatrix
+        self.visualRotationMatrix = visualRotationMatrix
+        self.normalizedScale = normalizedScale
+        self.framingRadius = framingRadius
+        self.surfaceRadius = surfaceRadius
+        self.worldPosition = worldPosition
+    }
 }

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/SceneSnapshot/UniverseSceneSnapshotPipeline.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/SceneSnapshot/UniverseSceneSnapshotPipeline.swift
@@ -65,13 +65,17 @@ final class UniverseSceneSnapshotPipeline: UniverseSceneSnapshotProviding {
 
             let parentWorldPosition = planet.parentName
                 .flatMap { worldPositionsByName[$0] }
-            let baseModelMatrix = planet.modelMatrix(at: simulationTime,
-                                                     parentWorldPosition: parentWorldPosition)
+            let orbitTransformMatrix = planet.orbitTransformMatrix(
+                at: simulationTime,
+                parentWorldPosition: parentWorldPosition
+            )
+            let visualRotationMatrix = planet.visualRotationMatrix(at: simulationTime)
+            let baseModelMatrix = orbitTransformMatrix * visualRotationMatrix
             let normalizedScale = planet.radius
             guard let presentationMetrics = presentationMetricsByBodyName[planet.name] else {
                 continue
             }
-            let worldPosition4 = baseModelMatrix * SIMD4<Float>(0, 0, 0, 1)
+            let worldPosition4 = orbitTransformMatrix * SIMD4<Float>(0, 0, 0, 1)
             let worldPosition = SIMD3<Float>(worldPosition4.x,
                                              worldPosition4.y,
                                              worldPosition4.z)
@@ -81,6 +85,8 @@ final class UniverseSceneSnapshotPipeline: UniverseSceneSnapshotProviding {
                 CelestialBodySnapshot(
                     planetName: planet.name,
                     baseModelMatrix: baseModelMatrix,
+                    orbitTransformMatrix: orbitTransformMatrix,
+                    visualRotationMatrix: visualRotationMatrix,
                     normalizedScale: normalizedScale,
                     framingRadius: presentationMetrics.framingRadius,
                     surfaceRadius: presentationMetrics.surfaceRadius,
@@ -99,13 +105,23 @@ final class UniverseSceneSnapshotPipeline: UniverseSceneSnapshotProviding {
 extension Planet {
     nonisolated func modelMatrix(at time: Float,
                                  parentWorldPosition: SIMD3<Float>? = nil) -> float4x4 {
+        orbitTransformMatrix(at: time, parentWorldPosition: parentWorldPosition)
+            * visualRotationMatrix(at: time)
+    }
+
+    nonisolated func orbitTransformMatrix(at time: Float,
+                                          parentWorldPosition: SIMD3<Float>? = nil) -> float4x4 {
         let orbitAngle = time * orbitSpeed
-        let orbitRotation = float4x4.makeRotationZ(orbitAngle)
+        // Presentation orbits are stylized circular paths in RealityKit's XZ plane.
+        let orbitRotation = float4x4.makeRotationY(orbitAngle)
         let orbitalTranslation = float4x4.makeTranslation([distance, 0, 0])
-        let selfSpin = float4x4.makeRotationZ(time * rotationSpeedKmSec)
         let parentTranslation = float4x4.makeTranslation(parentWorldPosition ?? .zero)
 
         // Transformations are applied right to left.
-        return parentTranslation * orbitRotation * orbitalTranslation * selfSpin
+        return parentTranslation * orbitRotation * orbitalTranslation
+    }
+
+    nonisolated func visualRotationMatrix(at time: Float) -> float4x4 {
+        float4x4.makeRotationY(time * rotationSpeedKmSec)
     }
 }

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
@@ -259,7 +259,7 @@ final class UniverseSceneCoordinator {
             orbitTransform.addChild(rotationTransform)
             rotationTransform.addChild(visualRoot)
             if planet.name == "Sun" {
-                bodyRoot.addChild(sunLight)
+                orbitTransform.addChild(sunLight)
             }
             celestialSystemRoot.addChild(bodyRoot)
             bodyEntities[planet.name] = BodyEntities(bodyRoot: bodyRoot,
@@ -326,11 +326,9 @@ final class UniverseSceneCoordinator {
         guard let snapshot = frameState.snapshot else { return }
         for packet in snapshot.planets {
             guard let entities = bodyEntities[packet.planetName] else { continue }
-            entities.bodyRoot.position = packet.worldPosition - cameraSnapshot.sceneOrigin
-
-            var localModelMatrix = packet.baseModelMatrix
-            localModelMatrix.columns.3 = SIMD4<Float>(0, 0, 0, 1)
-            entities.rotationTransform.transform = Transform(matrix: localModelMatrix)
+            entities.bodyRoot.position = -cameraSnapshot.sceneOrigin
+            entities.orbitTransform.transform = Transform(matrix: packet.orbitTransformMatrix)
+            entities.rotationTransform.transform = Transform(matrix: packet.visualRotationMatrix)
             if bodyDescriptors[packet.planetName]?.usesSnapshotScale == true {
                 entities.visualRoot.scale = SIMD3<Float>(repeating: packet.normalizedScale)
             }

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/HohmannTransferOrbitTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/HohmannTransferOrbitTests.swift
@@ -24,6 +24,8 @@ import Testing
 
     #expect(abs(simd_length(firstPoint) - 1) < 0.0001)
     #expect(abs(simd_length(lastPoint) - 1.52) < 0.0001)
+    #expect(abs(firstPoint.y) < 0.0001)
+    #expect(abs(lastPoint.y) < 0.0001)
     #expect(lastPoint.x < 0)
 }
 
@@ -42,8 +44,8 @@ import Testing
     #expect(abs(simd_length(lastPoint) - 0.38) < 0.0001)
 }
 
-@Test func transferArcRotatesFirstPointToEarthDirection() throws {
-    let earthDirection = normalize(SIMD3<Float>(0.25, 0.75, 0))
+@Test func transferArcRotatesFirstPointToEarthDirectionInXZPlane() throws {
+    let earthDirection = normalize(SIMD3<Float>(0.25, 0, -0.75))
     let transfer = try #require(HohmannTransferOrbit.make(
         destinationName: "Mars",
         planets: testPlanets,
@@ -54,6 +56,17 @@ import Testing
     let firstPoint = normalize(try #require(transfer.points.first))
 
     #expect(simd_distance(firstPoint, earthDirection) < 0.0001)
+}
+
+@Test func transferArcRejectsDirectionsOutsideOrbitPlane() {
+    let transfer = HohmannTransferOrbit.make(
+        destinationName: "Mars",
+        planets: testPlanets,
+        earthSunDirection: SIMD3<Float>(0, 1, 0),
+        sampleCount: 16
+    )
+
+    #expect(transfer == nil)
 }
 
 @Test func unsupportedTransferTargetsReturnNil() {

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/RealityProceduralSceneContentTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/RealityProceduralSceneContentTests.swift
@@ -50,6 +50,18 @@ import Testing
 }
 
 @MainActor
+@Test func proceduralOrbitCirclePointsUseRealityKitXZPlane() throws {
+    let points = RealityProceduralSceneContent.circlePoints(center: SIMD3<Float>(10, 20, 30),
+                                                            radius: 4)
+    let firstPoint = try #require(points.first)
+    let quarterPoint = points[points.count / 4]
+
+    #expect(simd_distance(firstPoint, SIMD3<Float>(14, 20, 30)) < 0.0001)
+    #expect(simd_distance(quarterPoint, SIMD3<Float>(10, 20, 26)) < 0.0001)
+    #expect(points.allSatisfy { abs($0.y - 20) < 0.0001 })
+}
+
+@MainActor
 @Test func realityStarFieldUsesOneBatchedLowLevelMesh() throws {
     let starField = try RealityStarField(configuration: StarFieldConfiguration(density: 0.01))
     let model = try #require(starField.entity.components[ModelComponent.self])

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/RoutePathBuilderTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/RoutePathBuilderTests.swift
@@ -22,7 +22,7 @@ import Testing
 }
 
 @Test func routeBuilderExtendsTransferToDestinationOrbitPosition() throws {
-    let destinationPosition = SIMD3<Float>(0, -1.52, 0)
+    let destinationPosition = SIMD3<Float>(0, 0, 1.52)
     let route = try #require(RoutePathBuilder(sampleCount: 24).makeRoute(input: RouteBuildInput(
         destinationName: "Mars",
         planets: testPlanets,
@@ -36,6 +36,20 @@ import Testing
 
     #expect(simd_distance(finalPoint, destinationPosition) < 0.0001)
     #expect(route.points.count > 24)
+    #expect(route.points.allSatisfy { abs($0.y) < 0.0001 })
+}
+
+@Test func routeBuilderLeavesTransferArcWhenDestinationHasNoOrbitPlaneDirection() throws {
+    let route = try #require(RoutePathBuilder(sampleCount: 24).makeRoute(input: RouteBuildInput(
+        destinationName: "Mars",
+        planets: testPlanets,
+        earthSunDirection: SIMD3<Float>(1, 0, 0),
+        sunPosition: .zero,
+        destinationPosition: SIMD3<Float>(0, 1.52, 0),
+        estimatedDuration: 12
+    )))
+
+    #expect(route.points.count == 24)
 }
 
 @Test func routeBuilderRejectsUnsupportedDestinations() {

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/SurfaceCoordinateMathTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/SurfaceCoordinateMathTests.swift
@@ -10,15 +10,15 @@ import Testing
     expectVector(SurfaceCoordinateMath.localUnitVector(
         for: SurfaceCoordinate(latitudeDegrees: 0,
                                longitudeDegrees: 90)
-    ), equals: SIMD3<Float>(0, 1, 0))
+    ), equals: SIMD3<Float>(0, 0, 1))
     expectVector(SurfaceCoordinateMath.localUnitVector(
         for: SurfaceCoordinate(latitudeDegrees: 90,
                                longitudeDegrees: 42)
-    ), equals: SIMD3<Float>(0, 0, 1))
+    ), equals: SIMD3<Float>(0, 1, 0))
     expectVector(SurfaceCoordinateMath.localUnitVector(
         for: SurfaceCoordinate(latitudeDegrees: -90,
                                longitudeDegrees: 42)
-    ), equals: SIMD3<Float>(0, 0, -1))
+    ), equals: SIMD3<Float>(0, -1, 0))
 }
 
 @Test func surfaceCoordinateRoundTripsAwayFromPoles() throws {
@@ -107,7 +107,7 @@ import Testing
 
 @Test func worldSurfacePointUsesBaseModelMatrixAndSurfaceRadius() throws {
     let baseModelMatrix = float4x4.makeTranslation(SIMD3<Float>(10, 20, 30))
-    * float4x4.makeRotationZ(.pi / 2)
+    * float4x4.makeRotationY(.pi / 2)
     let planet = testSurfacePlanet(baseModelMatrix: baseModelMatrix,
                                    surfaceRadius: 2)
 
@@ -120,7 +120,7 @@ import Testing
                                                                    forWorldPoint: worldPoint))
 
     expectVector(worldPoint,
-                 equals: SIMD3<Float>(10, 22, 30))
+                 equals: SIMD3<Float>(10, 20, 28))
     expectEqual(coordinate.latitudeDegrees,
                 0)
     expectEqual(coordinate.longitudeDegrees,

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
@@ -24,7 +24,7 @@ import Testing
 
     let sun = try #require(coordinator.bodyEntities["Sun"])
     #expect(coordinator.sunLight.name == CelestialLightingConfiguration.SunPointLight.entityName)
-    #expect(coordinator.sunLight.parent == sun.bodyRoot)
+    #expect(coordinator.sunLight.parent == sun.orbitTransform)
     #expect(coordinator.sunLight.position == .zero)
     let sunLightComponent = try #require(
         coordinator.sunLight.components[PointLightComponent.self]
@@ -128,9 +128,11 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
     coordinator.update(deltaTime: 0.1)
     let initialFrame = try #require(coordinator.latestFrameState)
     let sunPosition = SIMD3<Float>(100, 20, -30)
+    let orbitTransformMatrix = float4x4.makeTranslation(sunPosition)
     let packet = CelestialBodySnapshot(
         planetName: "Sun",
-        baseModelMatrix: matrix_identity_float4x4,
+        baseModelMatrix: orbitTransformMatrix,
+        orbitTransformMatrix: orbitTransformMatrix,
         normalizedScale: 1,
         framingRadius: 1,
         surfaceRadius: 1,
@@ -336,16 +338,135 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
 }
 
 @MainActor
-@Test func migratedBodyRetainsSnapshotRotationAndVisualCorrection() async throws {
+@Test func sceneSnapshotPipelineEmitsVisualSelfRotation() async throws {
+    let planet = Planet(name: "Sun",
+                        meshName: "Sun",
+                        parentName: nil,
+                        radius: 1,
+                        distance: 2,
+                        orbitSpeed: 0.25,
+                        rotationSpeedKmSec: 0.5)
+    let pipeline = UniverseSceneSnapshotPipeline(planets: [planet])
+    pipeline.setPresentationMetrics([
+        planet.name: CelestialBodyPresentationMetrics(renderRadius: 1,
+                                                      framingRadius: 1,
+                                                      surfaceRadius: 1)
+    ])
+
+    pipeline.requestPreparation(simulationTime: 2)
+    while pipeline.latestSnapshot == nil {
+        await Task.yield()
+    }
+
+    let packet = try #require(pipeline.latestSnapshot?.planet(named: planet.name))
+    let expectedVisualRotation = float4x4.makeRotationY(1)
+    let expectedOrbitTransform = planet.orbitTransformMatrix(at: 2)
+    let expectedBaseModelMatrix = planet.modelMatrix(at: 2)
+    expectSceneMatrix(packet.orbitTransformMatrix,
+                      equals: expectedOrbitTransform)
+    expectSceneMatrix(packet.visualRotationMatrix,
+                      equals: expectedVisualRotation)
+    expectSceneMatrix(packet.baseModelMatrix,
+                      equals: expectedBaseModelMatrix)
+    #expect(abs(packet.visualRotationMatrix[0][0] - 1) > 0.00001)
+}
+
+@MainActor
+@Test func sceneSnapshotPipelineSpinsVisibleBodiesAroundRealityKitUpAxis() async throws {
+    let bodyNames = Set(["Mercury", "Earth", "Jupiter", "Saturn", "Neptune"])
+    let planets = SolarSystemLoader.loadPlanets(from: "planets")
+        .filter { bodyNames.contains($0.name) }
+    let pipeline = UniverseSceneSnapshotPipeline(planets: planets)
+    pipeline.setPresentationMetrics(
+        Dictionary(uniqueKeysWithValues: planets.map {
+            ($0.name, CelestialBodyPresentationMetrics(renderRadius: 1,
+                                                       framingRadius: 1,
+                                                       surfaceRadius: 1))
+        })
+    )
+    let simulationTime: Float = 100_000
+
+    pipeline.requestPreparation(simulationTime: simulationTime)
+    while pipeline.latestSnapshot == nil {
+        await Task.yield()
+    }
+
+    let snapshot = try #require(pipeline.latestSnapshot)
+    for planet in planets {
+        let packet = try #require(snapshot.planet(named: planet.name))
+        let expectedRotation = float4x4.makeRotationY(simulationTime * planet.rotationSpeedKmSec)
+        expectSceneMatrix(packet.visualRotationMatrix,
+                          equals: expectedRotation)
+        #expect(abs(packet.visualRotationMatrix[1][1] - 1) <= 0.00001)
+        #expect(abs(packet.visualRotationMatrix[0][1]) <= 0.00001)
+        #expect(abs(packet.visualRotationMatrix[1][0]) <= 0.00001)
+        #expect(abs(packet.visualRotationMatrix[1][2]) <= 0.00001)
+        #expect(abs(packet.visualRotationMatrix[2][1]) <= 0.00001)
+    }
+}
+
+@MainActor
+@Test func sceneSnapshotPipelineEmitsParentRelativeOrbitMotion() async throws {
+    let earth = Planet(name: "Earth",
+                       meshName: "Earth",
+                       parentName: nil,
+                       radius: 1,
+                       distance: 10,
+                       orbitSpeed: 0,
+                       rotationSpeedKmSec: 0)
+    let moon = Planet(name: "Moon",
+                      meshName: "Moon",
+                      parentName: "Earth",
+                      radius: 1,
+                      distance: 2,
+                      orbitSpeed: 0.5,
+                      rotationSpeedKmSec: 0)
+    let pipeline = UniverseSceneSnapshotPipeline(planets: [earth, moon])
+    pipeline.setPresentationMetrics([
+        earth.name: CelestialBodyPresentationMetrics(renderRadius: 1,
+                                                     framingRadius: 1,
+                                                     surfaceRadius: 1),
+        moon.name: CelestialBodyPresentationMetrics(renderRadius: 1,
+                                                    framingRadius: 1,
+                                                    surfaceRadius: 1)
+    ])
+
+    pipeline.requestPreparation(simulationTime: Float.pi)
+    while pipeline.latestSnapshot == nil {
+        await Task.yield()
+    }
+
+    let snapshot = try #require(pipeline.latestSnapshot)
+    let earthPacket = try #require(snapshot.planet(named: earth.name))
+    let moonPacket = try #require(snapshot.planet(named: moon.name))
+    let expectedMoonOrbit = moon.orbitTransformMatrix(
+        at: Float.pi,
+        parentWorldPosition: earthPacket.worldPosition
+    )
+
+    expectSceneMatrix(moonPacket.orbitTransformMatrix,
+                      equals: expectedMoonOrbit)
+    expectVector(earthPacket.worldPosition,
+                 equals: SIMD3<Float>(10, 0, 0))
+    expectVector(moonPacket.worldPosition,
+                 equals: SIMD3<Float>(10, 0, -2))
+}
+
+@MainActor
+@Test func migratedBodyAppliesVisualRotationAndRetainsVisualCorrection() async throws {
     let resources = UniverseModuleResources()
     try await resources.prepare()
     resources.sceneCoordinator.setViewportSize(CGSize(width: 390, height: 844))
     resources.sceneCoordinator.update(deltaTime: 0.1)
     let initialFrame = try #require(resources.sceneCoordinator.latestFrameState)
-    let rotation = float4x4.makeRotationZ(.pi / 3)
+    let orbitTransform = float4x4.makeRotationY(.pi / 6)
+        * float4x4.makeTranslation(SIMD3<Float>(2, 0, 0))
+    let visualRotation = float4x4.makeRotationY(.pi / 3)
     let packet = CelestialBodySnapshot(
         planetName: "Sun",
-        baseModelMatrix: rotation,
+        baseModelMatrix: orbitTransform * visualRotation,
+        orbitTransformMatrix: orbitTransform,
+        visualRotationMatrix: visualRotation,
         normalizedScale: 1,
         framingRadius: 1,
         surfaceRadius: 1,
@@ -363,7 +484,10 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
 
     resources.sceneCoordinator.apply(frameState: frame)
 
-    expectSceneMatrix(sun.rotationTransform.transform.matrix, equals: rotation)
+    expectSceneMatrix(sun.orbitTransform.transform.matrix,
+                      equals: orbitTransform)
+    expectSceneMatrix(sun.rotationTransform.transform.matrix,
+                      equals: visualRotation)
     #expect(sun.visualRoot.transform == visualTransform)
 }
 
@@ -397,9 +521,11 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
     coordinator.update(deltaTime: 0.5)
     let initialFrame = try #require(coordinator.latestFrameState)
     let bodyPosition = SIMD3<Float>(10, 20, 30)
+    let orbitTransformMatrix = float4x4.makeTranslation(bodyPosition)
     let packet = CelestialBodySnapshot(
         planetName: "Earth",
-        baseModelMatrix: matrix_identity_float4x4,
+        baseModelMatrix: orbitTransformMatrix,
+        orbitTransformMatrix: orbitTransformMatrix,
         normalizedScale: 1,
         framingRadius: 1,
         surfaceRadius: 1,
@@ -416,7 +542,9 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
     coordinator.apply(frameState: frame)
 
     let earth = try #require(coordinator.bodyEntities["Earth"])
-    #expect(earth.bodyRoot.position == bodyPosition - initialFrame.cameraSnapshot.sceneOrigin)
+    #expect(earth.bodyRoot.position == -initialFrame.cameraSnapshot.sceneOrigin)
+    expectSceneMatrix(earth.orbitTransform.transform.matrix,
+                      equals: orbitTransformMatrix)
     let cameraComponent = try #require(
         coordinator.virtualCamera.components[ProjectiveTransformCameraComponent.self]
     )
@@ -515,4 +643,12 @@ private func expectSceneMatrix(_ lhs: float4x4,
             #expect(abs(lhs[column][row] - rhs[column][row]) <= tolerance)
         }
     }
+}
+
+private func expectVector(_ lhs: SIMD3<Float>,
+                          equals rhs: SIMD3<Float>,
+                          tolerance: Float = 0.00001) {
+    #expect(abs(lhs.x - rhs.x) <= tolerance)
+    #expect(abs(lhs.y - rhs.y) <= tolerance)
+    #expect(abs(lhs.z - rhs.z) <= tolerance)
 }


### PR DESCRIPTION
## Summary
- Correct surface coordinate math to match the repository's X/Y/Z axis conventions
- Split planet transforms into orbit motion and visual self-rotation, and carry both through scene snapshots
- Update the RealityKit coordinator to apply orbit, rotation, and sun lighting on the proper entity hierarchy
- Expand tests to cover coordinate round-trips, orbit-relative motion, and visual rotation behavior

Part of #359 

## Testing
- Added/updated unit coverage for surface coordinate conversion and world-surface point math
- Added scene snapshot and coordinator tests for orbit transform propagation, self-rotation, and sun light attachment
- Not run (not requested)