### PR TITLE
Add configured animation playback for celestial assets

### DIFF
--- a/Modules/UniverseModule/Sources/UniverseModule/Assets/Models/celestial_assets.json
+++ b/Modules/UniverseModule/Sources/UniverseModule/Assets/Models/celestial_assets.json
@@ -53,7 +53,13 @@
             "orientationCorrection": { "x": 0, "y": 0, "z": 0, "w": 1 },
             "renderRadius": 0.006378,
             "framingRadius": 0.00645,
-            "surfaceRadius": 0.006378
+            "surfaceRadius": 0.006378,
+            "animations": [
+                {
+                    "name": "Loop_SpinAnimation",
+                    "repeats": true
+                }
+            ]
         },
         {
             "identity": "moon",
@@ -95,7 +101,13 @@
             "orientationCorrection": { "x": 0, "y": 0, "z": 0, "w": 1 },
             "renderRadius": 0.071492,
             "framingRadius": 0.0722,
-            "surfaceRadius": 0.071492
+            "surfaceRadius": 0.071492,
+            "animations": [
+                {
+                    "name": "Loop",
+                    "repeats": true
+                }
+            ]
         },
         {
             "identity": "saturn",

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/CelestialAssetManifest.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/CelestialAssetManifest.swift
@@ -30,6 +30,27 @@ struct CelestialAssetQuaternion: Decodable, Sendable, Equatable {
     var values: [Float] { [xAxis, yAxis, zAxis, real] }
 }
 
+struct CelestialAssetAnimationDescriptor: Decodable, Sendable, Equatable {
+    let name: String
+    let repeats: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case repeats
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        repeats = try container.decodeIfPresent(Bool.self, forKey: .repeats) ?? true
+    }
+
+    init(name: String, repeats: Bool = true) {
+        self.name = name
+        self.repeats = repeats
+    }
+}
+
 struct CelestialAssetManifest: Decodable, Sendable {
     enum ValidationError: Error, Equatable {
         case emptyManifest
@@ -92,6 +113,7 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
     let renderRadius: Float
     let framingRadius: Float
     let surfaceRadius: Float
+    let animations: [CelestialAssetAnimationDescriptor]
 
     var assetName: String {
         URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
@@ -116,6 +138,7 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
         case renderRadius
         case framingRadius
         case surfaceRadius
+        case animations
     }
 
     init(from decoder: Decoder) throws {
@@ -138,6 +161,8 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
         renderRadius = try container.decode(Float.self, forKey: .renderRadius)
         framingRadius = try container.decode(Float.self, forKey: .framingRadius)
         surfaceRadius = try container.decode(Float.self, forKey: .surfaceRadius)
+        animations = try container.decodeIfPresent([CelestialAssetAnimationDescriptor].self,
+                                                    forKey: .animations) ?? []
     }
 
     init(identity: String,
@@ -153,7 +178,8 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
          orientationCorrection: CelestialAssetQuaternion,
          renderRadius: Float,
          framingRadius: Float,
-         surfaceRadius: Float) {
+         surfaceRadius: Float,
+         animations: [CelestialAssetAnimationDescriptor] = []) {
         self.identity = identity
         self.displayName = displayName
         self.filename = filename
@@ -168,6 +194,7 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
         self.renderRadius = renderRadius
         self.framingRadius = framingRadius
         self.surfaceRadius = surfaceRadius
+        self.animations = animations
     }
 
     fileprivate func validate() throws {
@@ -184,6 +211,11 @@ struct CelestialAssetDescriptor: Decodable, Sendable, Equatable {
         where rootName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw CelestialAssetManifest.ValidationError.emptyValue(identity: identity,
                                                                     field: "additionalRootNames")
+        }
+        for animation in animations
+        where animation.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw CelestialAssetManifest.ValidationError.emptyValue(identity: identity,
+                                                                    field: "animations")
         }
         guard Set(rootNames).count == rootNames.count else {
             throw CelestialAssetManifest.ValidationError.emptyValue(identity: identity,

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
@@ -74,6 +74,7 @@ final class UniverseSceneCoordinator {
         updateSubscription?.cancel()
         updateSubscription = nil
         attachSceneIfNeeded(to: &content, installationID: installationID)
+        resumeConfiguredAnimationsIfNeeded()
         subscribeToUpdates(in: content)
     }
 
@@ -84,6 +85,7 @@ final class UniverseSceneCoordinator {
             return
         }
         attachSceneIfNeeded(to: &content, installationID: installationID)
+        resumeConfiguredAnimationsIfNeeded()
         guard updateSubscription == nil else { return }
         subscribeToUpdates(in: content)
     }
@@ -377,6 +379,16 @@ final class UniverseSceneCoordinator {
         }
         if !controllers.isEmpty {
             animationPlaybackControllers[descriptor.displayName] = controllers
+        }
+    }
+
+    func resumeConfiguredAnimationsIfNeeded() {
+        for (bodyName, descriptor) in bodyDescriptors where !descriptor.animations.isEmpty {
+            guard animationPlaybackControllers[bodyName]?.isEmpty != false,
+                  let assetRoot = bodyEntities[bodyName]?.visualRoot.children.first else {
+                continue
+            }
+            playConfiguredAnimations(for: descriptor, on: assetRoot)
         }
     }
 

--- a/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
+++ b/Modules/UniverseModule/Sources/UniverseModule/RealityKit/UniverseSceneCoordinator.swift
@@ -28,6 +28,7 @@ final class UniverseSceneCoordinator {
     private(set) var bodyEntities: [String: BodyEntities] = [:]
     private(set) var realityKitOwnedBodyNames: Set<String> = []
     private(set) var isProceduralSceneContentPrepared = false
+    private(set) var animationPlaybackControllers: [String: [AnimationPlaybackController]] = [:]
 
     private let snapshotProvider: SnapshotProvider
     private let cameraCoordinator: CameraCoordinator
@@ -155,9 +156,11 @@ final class UniverseSceneCoordinator {
             guard let entities = bodyEntities[descriptor.displayName] else {
                 throw PreparationError.missingBody(descriptor.displayName)
             }
+            stopAnimations(for: descriptor.displayName)
             entities.visualRoot.children.removeAll()
             entities.visualRoot.transform = descriptor.visualCorrectionTransform
             entities.visualRoot.addChild(assetRoot)
+            playConfiguredAnimations(for: descriptor, on: assetRoot)
         }
         install(proceduralSceneContent: preparedProceduralSceneContent)
         bodyDescriptors = Dictionary(uniqueKeysWithValues: manifest.assets.map {
@@ -220,6 +223,7 @@ final class UniverseSceneCoordinator {
         updateSubscription?.cancel()
         updateSubscription = nil
         assetRepository.cancelPendingLoads()
+        stopAllAnimations()
         universeRoot.removeFromParent()
         installationRoot = nil
         activeInstallationID = nil
@@ -351,6 +355,63 @@ final class UniverseSceneCoordinator {
         navigationRouteRoot.addChild(navigationMarkerRoot)
         navigationMarkerRoot.addChild(proceduralSceneContent.navigationMarker)
         self.proceduralSceneContent = proceduralSceneContent
+    }
+
+    private func playConfiguredAnimations(for descriptor: CelestialAssetDescriptor,
+                                          on assetRoot: Entity) {
+        guard !descriptor.animations.isEmpty else { return }
+        let availableAnimations = assetRoot.availableAnimations.reduce(
+            into: [String: AnimationResource]()
+        ) { animationsByName, animation in
+            animationsByName[animation.name] = animationsByName[animation.name] ?? animation
+        }
+        var controllers: [AnimationPlaybackController] = []
+        controllers.reserveCapacity(descriptor.animations.count)
+        for configuredAnimation in descriptor.animations {
+            let animationOwnerAndResource = availableAnimations[configuredAnimation.name].map {
+                (assetRoot, $0)
+            } ?? animationResource(named: configuredAnimation.name, in: assetRoot)
+            guard let (animationOwner, animation) = animationOwnerAndResource else { continue }
+            let playbackAnimation = configuredAnimation.repeats ? animation.repeat() : animation
+            controllers.append(animationOwner.playAnimation(playbackAnimation))
+        }
+        if !controllers.isEmpty {
+            animationPlaybackControllers[descriptor.displayName] = controllers
+        }
+    }
+
+    private func stopAnimations(for bodyName: String) {
+        animationPlaybackControllers[bodyName]?.forEach { $0.stop() }
+        animationPlaybackControllers[bodyName] = nil
+    }
+
+    private func stopAllAnimations() {
+        animationPlaybackControllers.values.flatMap { $0 }.forEach { $0.stop() }
+        animationPlaybackControllers.removeAll()
+    }
+
+    private func animationResource(named name: String,
+                                   in entity: Entity) -> (Entity, AnimationResource)? {
+        if let animationLibrary = entity.components[AnimationLibraryComponent.self] {
+            if let animation = animationLibrary.animations[name] {
+                return (entity, animation)
+            }
+            if let animation = animationLibrary.animations.first(where: {
+                Self.animationKey($0.key, matches: name)
+            })?.value {
+                return (entity, animation)
+            }
+        }
+        for child in entity.children {
+            if let animation = animationResource(named: name, in: child) {
+                return animation
+            }
+        }
+        return nil
+    }
+
+    private static func animationKey(_ key: String, matches configuredName: String) -> Bool {
+        key.split(separator: "/").last.map(String.init) == configuredName
     }
 
     static func makeRealityKitProjection(

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/CelestialAssetManifestTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/CelestialAssetManifestTests.swift
@@ -12,6 +12,13 @@ import Testing
     #expect(manifest.assets.allSatisfy { $0.filename.hasSuffix(".usdz") })
     #expect(manifest.assets.allSatisfy { $0.modelToUniverseScale.isFinite })
     #expect(manifest.assets.allSatisfy { $0.referenceRadius.isFinite })
+
+    let earth = try #require(manifest.assets.first { $0.identity == "earth" })
+    let jupiter = try #require(manifest.assets.first { $0.identity == "jupiter" })
+    let animatedIdentities = Set(manifest.assets.filter { !$0.animations.isEmpty }.map(\.identity))
+    #expect(animatedIdentities == ["earth", "jupiter"])
+    #expect(earth.animations == [.init(name: "Loop_SpinAnimation")])
+    #expect(jupiter.animations == [.init(name: "Loop")])
 }
 
 @Test func celestialAssetManifestRejectsDuplicateIdentities() {
@@ -28,6 +35,10 @@ import Testing
                                            modelToUniverseScale: .infinity)
     let missingParent = makeAssetDescriptor(identity: "neptune",
                                             parentIdentity: "sun")
+    let emptyAnimationName = makeAssetDescriptor(
+        identity: "earth",
+        animations: [.init(name: " \n ")]
+    )
 
     #expect(
         throws: CelestialAssetManifest.ValidationError.invalidNumericValue(
@@ -44,6 +55,14 @@ import Testing
         )
     ) {
         try CelestialAssetManifest(assets: [missingParent]).validated()
+    }
+    #expect(
+        throws: CelestialAssetManifest.ValidationError.emptyValue(
+            identity: "earth",
+            field: "animations"
+        )
+    ) {
+        try CelestialAssetManifest(assets: [emptyAnimationName]).validated()
     }
 }
 
@@ -76,6 +95,10 @@ import Testing
             let coronaModel = try #require(corona.components[ModelComponent.self])
             #expect(!coronaModel.materials.isEmpty)
         }
+
+        for animation in asset.animations {
+            #expect(containsAnimation(named: animation.name, in: root))
+        }
     }
 }
 
@@ -92,10 +115,25 @@ private func firstModelComponent(in entity: Entity) -> ModelComponent? {
     return nil
 }
 
+private func containsAnimation(named name: String, in entity: Entity) -> Bool {
+    if let animationLibrary = entity.components[AnimationLibraryComponent.self] {
+        if animationLibrary.animations[name] != nil {
+            return true
+        }
+        if animationLibrary.animations.contains(where: {
+            $0.key.split(separator: "/").last.map(String.init) == name
+        }) {
+            return true
+        }
+    }
+    return entity.children.contains { containsAnimation(named: name, in: $0) }
+}
+
 private func makeAssetDescriptor(
     identity: String,
     parentIdentity: String? = nil,
-    modelToUniverseScale: Float = 1
+    modelToUniverseScale: Float = 1,
+    animations: [CelestialAssetAnimationDescriptor] = []
 ) -> CelestialAssetDescriptor {
     CelestialAssetDescriptor(
         identity: identity,
@@ -111,6 +149,7 @@ private func makeAssetDescriptor(
         orientationCorrection: .init(xAxis: 0, yAxis: 0, zAxis: 0, real: 1),
         renderRadius: 1,
         framingRadius: 1,
-        surfaceRadius: 1
+        surfaceRadius: 1,
+        animations: animations
     )
 }

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
@@ -219,6 +219,25 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
 }
 
 @MainActor
+@Test func sceneCoordinatorRestartsConfiguredAnimationsAfterDismantle() async throws {
+    let resources = UniverseModuleResources()
+    let coordinator = resources.sceneCoordinator
+
+    try await resources.prepare()
+    #expect(coordinator.animationPlaybackControllers["Earth"]?.count == 1)
+    #expect(coordinator.animationPlaybackControllers["Jupiter"]?.count == 1)
+
+    coordinator.dismantle()
+    #expect(coordinator.animationPlaybackControllers.isEmpty)
+
+    coordinator.resumeConfiguredAnimationsIfNeeded()
+
+    #expect(coordinator.animationPlaybackControllers["Earth"]?.count == 1)
+    #expect(coordinator.animationPlaybackControllers["Jupiter"]?.count == 1)
+    #expect(Set(coordinator.animationPlaybackControllers.keys) == ["Earth", "Jupiter"])
+}
+
+@MainActor
 @Test func failedCelestialBodyPreparationCommitsNoRealityKitOwnership() async throws {
     enum TestError: Error { case loadFailed }
     let repository = RealityAssetRepository { url in

--- a/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
+++ b/Modules/UniverseModule/Tests/UniverseModuleTests/UniverseSceneCoordinatorTests.swift
@@ -191,6 +191,10 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
 
     let sunVisualRoot = try #require(resources.sceneCoordinator.bodyEntities["Sun"]?.visualRoot)
     #expect(sunVisualRoot.findEntity(named: "Corona") != nil)
+    #expect(resources.sceneCoordinator.animationPlaybackControllers["Earth"]?.count == 1)
+    #expect(resources.sceneCoordinator.animationPlaybackControllers["Jupiter"]?.count == 1)
+    #expect(Set(resources.sceneCoordinator.animationPlaybackControllers.keys)
+            == ["Earth", "Jupiter"])
 }
 
 @MainActor
@@ -283,6 +287,7 @@ private func containsModelComponent(_ entity: Entity) -> Bool {
         try await preparation.value
     }
     #expect(resources.sceneCoordinator.realityKitOwnedBodyNames.isEmpty)
+    #expect(resources.sceneCoordinator.animationPlaybackControllers.isEmpty)
     #expect(resources.sceneCoordinator.bodyEntities["Sun"]?.visualRoot.children.isEmpty == true)
     #expect(resources.sceneCoordinator.bodyEntities["Neptune"]?.visualRoot.children.isEmpty == true)
 }


### PR DESCRIPTION
## Summary
- Add animation descriptors to celestial asset metadata and validate animation names
- Start configured RealityKit animations when assets are installed and stop them during replacement or teardown
- Expand tests to cover manifest parsing, animation discovery, and coordinator playback state

## Testing
- Unit tests updated for manifest validation and animation loading behavior
- Unit tests updated for scene coordinator animation lifecycle handling